### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,152 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+
+### Changed
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+
+### Deprecated
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+
+### Removed
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+
+### Fixed
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+
+### Security
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+
+## [0.1.0] - 2020-08-31
+First major-version-zero release
+[0.1.0](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase).
+
+Note that according to
+[Semantic Versioning Specification, Item 4](https://semver.org/#spec-item-4),
+> Major version zero (0.y.z) is for initial development. Anything MAY change at
+> any time. The public API SHOULD NOT be considered stable.
+
+[Unreleased]: https://github.com/ise621/building-envelope-data/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ise621/building-envelope-data/releases/tag/v0.1.0


### PR DESCRIPTION
First major-version-zero release [0.1.0](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase).

Note that according to [Semantic Versioning Specification, Item 4](https://semver.org/#spec-item-4),
> Major version zero (0.y.z) is for initial development. Anything MAY change at
> any time. The public API SHOULD NOT be considered stable.