### PR TITLE
Clean-up stakeholder JSON schema

### DIFF
--- a/schemas/building.json
+++ b/schemas/building.json
@@ -84,84 +84,84 @@
             "owners": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "The owners own the building at the moment indicated by the timestamp of this data. Each owner is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "The owners own the building at the moment indicated by the timestamp of this data."
               },
               "minItems": 1
             },
             "architects": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Architects offer to design the building. Each architect is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Architects offer to design the building."
               },
               "minItems": 1
             },
             "BIMmanager": {
-              "$ref": "stakeholder.json#/$defs/basicStakeholder",
-              "description": "The BIM manager MUST guarantee the uniqueness of the decentral identifiers. She is responsible for the database of the building at the moment indicated by the timestamp of this data. The BIM manager is identified by an id."
+              "$ref": "stakeholder.json",
+              "description": "The BIM manager MUST guarantee the uniqueness of the decentral identifiers. She is responsible for the database of the building at the moment indicated by the timestamp of this data."
             },
             "planners": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "The planners provide assistance to the stakeholders, for example for the detailed planning in a domain like structural analysis or the technical building plant. Each planner is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "The planners provide assistance to the stakeholders, for example for the detailed planning in a domain like structural analysis or the technical building plant."
               },
               "minItems": 1
             },
             "contractors": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Contractors offer to construct the whole building or parts of it. Each contractor is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Contractors offer to construct the whole building or parts of it."
               },
               "minItems": 1
             },
             "suppliers": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Suppliers offer to supply components for the building. Each supplier is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Suppliers offer to supply components for the building."
               },
               "minItems": 1
             },
             "investors": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Investors offer financial credits to the stakeholders or offer to buy the building from the owners. Each investor is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Investors offer financial credits to the stakeholders or offer to buy the building from the owners."
               },
               "minItems": 1
             },
             "tenants": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Tenants rent space in the building. Each tenant is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Tenants rent space in the building."
               },
               "minItems": 1
             },
             "publicAuthorities": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Public authorities grant permissions according to the current regulations. Each public authority is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Public authorities grant permissions according to the current regulations."
               },
               "minItems": 1
             },
             "assesors": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Assesors offer to rate a building for example regarding its sustainability. Each assesor is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Assesors offer to rate a building for example regarding its sustainability."
               },
               "minItems": 1
             },
             "facilityManagers": {
               "type": "array",
               "items": {
-                "$ref": "stakeholder.json#/$defs/basicStakeholder",
-                "description": "Facility managers are responsible for a good operation of the building. Each facility manager is identified by an id."
+                "$ref": "stakeholder.json",
+                "description": "Facility managers are responsible for a good operation of the building."
               },
               "minItems": 1
             }

--- a/schemas/calorimetric.json
+++ b/schemas/calorimetric.json
@@ -37,7 +37,7 @@
         },
         "creator": {
           "title": "Creator",
-          "$ref": "stakeholder.json#/$defs/creator"
+          "$ref": "stakeholder.json"
         },
         "createdAt": {
           "title": "Creation timestamp",

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -119,8 +119,8 @@
         "authors": {
           "type": "array",
           "items": {
-            "$ref": "stakeholder.json#/$defs/author",
-            "description": "This array lists all persons which have authored the publication"
+            "$ref": "stakeholder.json#/$defs/person",
+            "description": "Persons who authored the publication."
           },
           "minItems": 1
         }

--- a/schemas/component.json
+++ b/schemas/component.json
@@ -85,16 +85,16 @@
           "type": "object",
           "properties": {
             "owner": {
-              "$ref": "stakeholder.json#/$defs/basicStakeholder",
-              "description": "The id and description of the owner of the component"
+              "$ref": "stakeholder.json",
+              "description": "Owner of the component"
             },
             "manufacturer": {
-              "$ref": "stakeholder.json#/$defs/basicStakeholder",
-              "description": "The id and description of the manufacturer of the component"
+              "$ref": "stakeholder.json",
+              "description": "Manufacturer of the component"
             },
             "developer": {
-              "$ref": "stakeholder.json#/$defs/developer",
-              "description": "The id and description of the institution or person which developed the component"
+              "$ref": "stakeholder.json",
+              "description": "Institution or person which developed the component"
             }
           }
         },
@@ -202,16 +202,16 @@
           "type": "object",
           "properties": {
             "owner": {
-              "$ref": "stakeholder.json#/$defs/basicStakeholder",
-              "description": "The id and description of the owner of the component"
+              "$ref": "stakeholder.json",
+              "description": "Owner of the component"
             },
             "manufacturer": {
-              "$ref": "stakeholder.json#/$defs/basicStakeholder",
-              "description": "The id and description of the manufacturer of the component"
+              "$ref": "stakeholder.json",
+              "description": "Manufacturer of the component"
             },
             "developer": {
-              "$ref": "stakeholder.json#/$defs/developer",
-              "description": "The id and description of the institution or person which developed the component"
+              "$ref": "stakeholder.json",
+              "description": "Institution or person which developed the component"
             }
           }
         },

--- a/schemas/hygrothermal.json
+++ b/schemas/hygrothermal.json
@@ -36,7 +36,7 @@
         },
         "creator": {
           "title": "Creator",
-          "$ref": "stakeholder.json#/$defs/creator"
+          "$ref": "stakeholder.json"
         },
         "createdAt": {
           "title": "Creation timestamp",

--- a/schemas/method.json
+++ b/schemas/method.json
@@ -30,7 +30,7 @@
           "minItems": 1
         },
         "developer": {
-          "$ref": "stakeholder.json#/$defs/developer",
+          "$ref": "stakeholder.json",
           "description": "Who developed the method."
         },
         "reference": {
@@ -176,11 +176,11 @@
           "description": "A description of the database"
         },
         "owner": {
-          "$ref": "stakeholder.json#/$defs/basicStakeholder",
+          "$ref": "stakeholder.json#/$defs/institution",
           "description": "The institution which owns the database"
         },
         "admin": {
-          "$ref": "stakeholder.json#/$defs/basicStakeholder",
+          "$ref": "stakeholder.json#/$defs/institution",
           "description": "The institution which administrates the database"
         },
         "createdAt": {

--- a/schemas/optical.json
+++ b/schemas/optical.json
@@ -36,7 +36,7 @@
         },
         "creator": {
           "title": "Creator",
-          "$ref": "stakeholder.json#/$defs/creator"
+          "$ref": "stakeholder.json"
         },
         "createdAt": {
           "title": "Creation timestamp",

--- a/schemas/photovoltaic.json
+++ b/schemas/photovoltaic.json
@@ -36,7 +36,7 @@
         },
         "creator": {
           "title": "Creator",
-          "$ref": "stakeholder.json#/$defs/creator"
+          "$ref": "stakeholder.json"
         },
         "createdAt": {
           "title": "Creation timestamp",

--- a/schemas/stakeholder.json
+++ b/schemas/stakeholder.json
@@ -1,147 +1,153 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://www.buildingenvelopedata.org/schemas/stakeholder.json",
-  "title": "stakeholder data",
-  "description": "",
+  "title": "Stakeholder",
+  "description": "Institution or person",
   "$defs": {
     "contact": {
-      "title": "Contact data for an institution or person.",
+      "title": "Contact information",
       "type": "object",
       "properties": {
         "phone": {
           "type": "string",
-          "description": "Phone number of an institution or person"
+          "title": "Phone number"
         },
         "address": {
           "type": "string",
-          "description": "Postal address of an institution or person"
+          "title": "Postal address"
         },
         "email": {
           "type": "string",
           "format": "email",
-          "description": "E-mail address of an institution or person"
+          "title": "E-mail address"
         },
         "website": {
           "$ref": "common.json#/$defs/webAddress",
-          "description": "Website of an institution or person"
+          "title": "Website"
         }
       },
       "additionalProperties": false,
       "required": [],
       "minProperties": 1
     },
-    "basicStakeholder": {
-      "title": "The basic data of stakeholders which can be either an institution or a person.",
+    "accreditation": {
+      "type": "object",
+      "properties": {
+        "standard": {
+          "description": "Standard for which an institution is accredited.",
+          "$ref": "common.json#/$defs/standard"
+        },
+        "approvals": {
+          "description": "Approvals that the institution is accredited according to the standard.",
+          "$ref": "common.json#/$defs/approvals"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["standard", "approvals"]
+    },
+    "institution": {
+      "title": "Institution",
       "type": "object",
       "properties": {
         "id": {
-          "$ref": "identifier.json#/$defs/central",
-          "description": "This id represents the stakeholder."
+          "title": "Identifier",
+          "$ref": "identifier.json#/$defs/central"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "abbreviation": {
+          "title": "Abbreviation",
+          "$ref": "string.json#/$defs/abbreviation"
         },
         "description": {
-          "type": "string",
-          "description": "This explanation can specify the role of the stakeholder."
+          "title": "Description",
+          "type": "string"
+        },
+        "gnuPgKeys": {
+          "type": "array",
+          "items": {
+            "title": "GnuPG keys",
+            "description": "Used for digital signatures in approvals.",
+            "type": "string"
+          },
+          "minItems": 0
+        },
+        "contact": {
+          "title": "Contact information",
+          "$ref": "#/$defs/contact"
+        },
+        "accreditations": {
+          "title": "Accreditations",
+          "description": "Standards for which the institution is accredited.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/accreditation"
+          },
+          "minItems": 0
+        },
+        "affiliations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "title": "Kind",
+                "type": "string"
+              },
+              "person": {
+                "title": "Person",
+                "$ref": "#/$defs/person"
+              }
+            },
+            "additionalProperties": false,
+            "required": ["name", "person"]
+          },
+          "minItems": 0
         }
       },
       "additionalProperties": false,
       "required": ["id"]
     },
     "person": {
-      "title": "Data about a person.",
+      "title": "Person",
       "type": "object",
       "properties": {
         "id": {
-          "$ref": "identifier.json#/$defs/central",
-          "description": "This id represents the person"
+          "title": "Identifier",
+          "$ref": "identifier.json#/$defs/central"
         },
         "fullName": {
-          "type": "string",
-          "description": "Full name"
+          "title": "Full name",
+          "type": "string"
         },
-        "institution": {
+        "affiliation": {
+          "title": "Affiliation",
           "type": "object",
           "properties": {
-            "id": {
-              "$ref": "identifier.json#/$defs/central",
-              "description": "The affiliation of the person"
+            "kind": {
+              "title": "Kind",
+              "type": "string"
             },
-            "name": {
-              "type": "string",
-              "description": "The name of the affiliation of the person"
+            "institution": {
+              "title": "Institution",
+              "$ref": "#/$defs/institution"
             }
           },
           "additionalProperties": false,
-          "required": ["name"]
+          "required": ["name", "institution"]
         },
         "contact": {
-          "$ref": "#/$defs/contact",
-          "description": "How to contact the person"
-        }
-      },
-      "additionalProperties": false,
-      "required": []
-    },
-    "institution": {
-      "title": "Data about an institution.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "$ref": "identifier.json#/$defs/central",
-          "description": "This id represents the institution"
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the institution"
-        },
-        "abbreviation": {
-          "$ref": "string.json#/$defs/abbreviation",
-          "description": "The abbreviation of the institution in Latin alphabet."
-        },
-        "description": {
-          "type": "string",
-          "description": "The explanation can further explain the role of the institution."
-        },
-        "publicKey": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "A public key of the institution for cryptograpic signatures for approvals."
-          },
-          "minItems": 1
-        },
-        "contact": {
-          "$ref": "#/$defs/contact",
-          "description": "How to contact the institution"
-        },
-        "accreditations": {
-          "title": "An array of standards for which the institution is accredited.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/accreditation"
-          },
-          "minItems": 1
+          "title": "Contact information",
+          "$ref": "#/$defs/contact"
         }
       },
       "additionalProperties": false,
       "required": ["id"]
     },
-    "accreditation": {
-      "type": "object",
-      "properties": {
-        "standard": {
-          "$ref": "common.json#/$defs/standard",
-          "description": "The standard for which an institution is accredited."
-        },
-        "approvals": {
-          "$ref": "common.json#/$defs/approvals",
-          "description": "Approval that the institution is accredited according to the standard."
-        }
-      },
-      "additionalProperties": false,
-      "required": ["standard", "approvals"]
-    },
     "stakeholder": {
-      "oneOf": [
+      "anyOf": [
         {
           "$ref": "#/$defs/institution"
         },
@@ -149,58 +155,6 @@
           "$ref": "#/$defs/person"
         }
       ]
-    },
-    "owner": {
-      "$ref": "#/$defs/basicStakeholder",
-      "description": "The owner holds the rights for example on a component and is defined by an id."
-    },
-    "submitter": {
-      "$ref": "#/$defs/basicStakeholder",
-      "description": "The submitter submits data to a database and is defined by an id."
-    },
-    "manufacturer": {
-      "$ref": "#/$defs/basicStakeholder",
-      "description": "The manufacturer manufactures or supplies the component and is defined by an id."
-    },
-    "approver": {
-      "$ref": "#/$defs/basicStakeholder",
-      "description": "The approver states that data or a method fulfills certain requirements. She is defined by an id."
-    },
-    "admin": {
-      "$ref": "#/$defs/basicStakeholder",
-      "description": "The admin is in charge of a database and is defined by an id."
-    },
-    "author": {
-      "$ref": "#/$defs/person",
-      "description": "An author is a person who is named as one of the authors of a publication. This person is defined by an id."
-    },
-    "developer": {
-      "$ref": "#/$defs/basicStakeholder",
-      "description": "A developer is a stakeholder who has developed a method or component. This stakeholder is defined by an id."
-    },
-    "creator": {
-      "$ref": "#/$defs/basicStakeholder",
-      "description": "A creator is a stakeholder who has created a data set. This stakeholder is defined by an id."
-    },
-    "standardizer": {
-      "title": "A standardizer is an institution which has issued a standard. This institution is defined by an id.",
-      "type": "object",
-      "properties": {
-        "id": {
-          "$ref": "identifier.json#/$defs/central",
-          "description": "This id represents the institution which has created a standard."
-        },
-        "abbreviation": {
-          "$ref": "string.json#/$defs/abbreviation",
-          "description": "Abbreviation of the standardizer in Latin alphabet."
-        },
-        "description": {
-          "type": "string",
-          "description": "This explanation can specify the role of the institution which has created a standard."
-        }
-      },
-      "additionalProperties": false,
-      "required": ["id"]
     }
   },
   "$ref": "#/$defs/stakeholder"


### PR DESCRIPTION
What this pull request does:
* clean titles and descriptions
* associate GnuPG keys with institutions for digitial signatures
* use `anyOf` instead of `oneOf` for stakeholders to allow for instances that only specify an identifier
* remove definitions for specific roles like `creator`, `owner`, and many others, use stakeholder, institution, or person instead (note that the role description associated with the roles was not needed because the role information is already in the property names and descriptions)
* remove the reference definition `basicStakeholder`, use `stakeholder` instead (note that the role description associated with the reference `basicStakeholder` was not needed because the role information is already in the property names and descriptions whose value was of type `basicStakeholder` or some concretization of it like `creator`, `owner`, and many others)

For future reference: In case descriptions of roles are needed in the future, then edges should be used as elaborated in #18:
```json
    "stakeholderEdge": {
      "description": "Edge to a stakeholder in some role",
      "type": "object",
      "properties": {
        "stakeholder": {
          "title": "Stakeholder",
          "$ref": "#/$defs/stakeholder"
        },
        "role": {
          "description": "Role of the stakeholder",
          "type": "string"
        }
      },
      "additionalProperties": false,
      "required": ["stakeholder"]
    },
    "institutionEdge": {
      "description": "Edge to a institution in some role",
      "type": "object",
      "properties": {
        "institution": {
          "title": "Institution",
          "$ref": "#/$defs/institution"
        },
        "role": {
          "description": "Role of the institution",
          "type": "string"
        }
      },
      "additionalProperties": false,
      "required": ["institution"]
    },
    "personEdge": {
      "description": "Edge to a person in some role",
      "type": "object",
      "properties": {
        "person": {
          "title": "Person",
          "$ref": "#/$defs/person"
        },
        "role": {
          "description": "Role of the person",
          "type": "string"
        }
      },
      "additionalProperties": false,
      "required": ["person"]
    }
```