### PR TITLE
Restrict `direction` and `symmetries` in `opticalData`

### DIFF
--- a/examples/dbe/calorimetric/bistMeasurement.json
+++ b/examples/dbe/calorimetric/bistMeasurement.json
@@ -91,7 +91,10 @@
                       "uncertainty": 50,
                       "confidenceInterval": 68.3
                     },
-                    "direction": "nearnormal"
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    }
                   }
                 }
               ],

--- a/examples/dbe/koester.json
+++ b/examples/dbe/koester.json
@@ -15,7 +15,10 @@
               "dataPoints": [
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": {
                       "integral": "visible"
                     }

--- a/examples/dbe/optical/nearnormalHemisphericalSolarReflectanceAccordingToStandard.json
+++ b/examples/dbe/optical/nearnormalHemisphericalSolarReflectanceAccordingToStandard.json
@@ -29,7 +29,10 @@
               "dataPoints": [
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "integral": "solar" }
                   },
                   "emergence": {

--- a/examples/dbe/optical/nearnormalHemisphericalVisibleTransmittance.json
+++ b/examples/dbe/optical/nearnormalHemisphericalVisibleTransmittance.json
@@ -14,7 +14,10 @@
               "dataPoints": [
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "integral": "visible" }
                   },
                   "emergence": {

--- a/examples/dbe/optical/nearnormalNearnormalSpectrallyResolvedTransmittance.json
+++ b/examples/dbe/optical/nearnormalNearnormalSpectrallyResolvedTransmittance.json
@@ -14,11 +14,17 @@
               "dataPoints": [
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "wavelength": 500 }
                   },
                   "emergence": {
-                    "direction": "nearnormal"
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    }
                   },
                   "results": {
                     "transmittance": {
@@ -28,11 +34,17 @@
                 },
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "wavelength": 1000 }
                   },
                   "emergence": {
-                    "direction": "nearnormal"
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    }
                   },
                   "results": {
                     "transmittance": {
@@ -42,11 +54,17 @@
                 },
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "wavelength": 1500 }
                   },
                   "emergence": {
-                    "direction": "nearnormal"
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    }
                   },
                   "results": {
                     "transmittance": {

--- a/examples/dbe/origin/methodAccordingToStandard.json
+++ b/examples/dbe/origin/methodAccordingToStandard.json
@@ -29,7 +29,10 @@
               "dataPoints": [
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "integral": "solar" }
                   },
                   "emergence": {

--- a/examples/dbe/origin/methodAsAservice.json
+++ b/examples/dbe/origin/methodAsAservice.json
@@ -44,7 +44,10 @@
               "dataPoints": [
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "integral": "solar" }
                   },
                   "emergence": {

--- a/examples/dbe/origin/originMethodAccordingToStandard.json
+++ b/examples/dbe/origin/originMethodAccordingToStandard.json
@@ -44,7 +44,10 @@
               "dataPoints": [
                 {
                   "incidence": {
-                    "direction": "nearnormal",
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
                     "wavelengths": { "integral": "solar" }
                   },
                   "emergence": {

--- a/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json
+++ b/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json
@@ -215,22 +215,20 @@
                         "percentage": 80
                       }
                     ],
-                    "angleDependency": {
-                      "incidenceAngleModifier": [
-                        {
-                          "incidence": 0,
-                          "IAM": 1
-                        },
-                        {
-                          "incidence": 60,
-                          "IAM": 0.924
-                        },
-                        {
-                          "incidence": 90,
-                          "IAM": 0
-                        }
-                      ]
-                    }
+                    "angleDependency": [
+                      {
+                        "incidence": 0,
+                        "IAM": 1
+                      },
+                      {
+                        "incidence": 60,
+                        "IAM": 0.924
+                      },
+                      {
+                        "incidence": 90,
+                        "IAM": 0
+                      }
+                    ]
                   },
                   "voltage": {
                     "nominal": {

--- a/schemas/number.json
+++ b/schemas/number.json
@@ -182,6 +182,30 @@
       "maximum": 360.0,
       "description": "A unit to measure angles. A full rotation equals 360°. This type is used for cases in which the option of an uncertainty is not desired."
     },
+    "degreeWithUncertainty": {
+      "title": "Degree with uncertainty",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "uncertainValue": {
+              "$ref": "#/$defs/degree"
+            },
+            "uncertainty": {
+              "$ref": "#/$defs/uncertaintyNumber"
+            },
+            "confidenceInterval": {
+              "$ref": "#/$defs/confidenceInterval"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["uncertainValue"]
+        },
+        {
+          "$ref": "#/$defs/degree"
+        }
+      ]
+    },
     "radian": {
       "type": "number",
       "description": "A unit to measure angles. A full rotation equals 2*Pi. This type is used for cases in which the option of an uncertainty is not desired."

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -267,7 +267,7 @@
           "properties": {
             "polar": {
               "$ref": "number.json#/$defs/degreeWithUncertainty",
-              "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has rotational symmetry, then the polar angle is sufficient to define the direction of incidence. If the sample has profile angle symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
+              "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has incidence-angle symmetry, then the polar angle is sufficient to define the direction of incidence. If the sample has profile angle symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
             },
             "azimuth": {
               "$ref": "number.json#/$defs/degreeWithUncertainty",

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -259,7 +259,7 @@
     },
     "incidenceDirection": {
       "title": "Incidence direction",
-      "description": "Direction of incident radiation on sample.",
+      "description": "Direction of incident radiation on sample. An incidence angle of 10° or less as defined in the technical report [CIE 130-1998, Practical methods for the measurement of reflectance and transmittance](http://cie.co.at/publications/practical-methods-measurement-reflectance-and-transmittance) is called 'nearnormal' and said to be 'almost perpendicular'.",
       "oneOf": [
         {
           "oneOf": [
@@ -278,12 +278,6 @@
               },
               "additionalProperties": false,
               "required": ["polar"]
-            },
-            {
-              "title": "Nearnormal",
-              "description": "Incidence angle of 10° or less as defined in the technical report [CIE 130-1998, Practical methods for the measurement of reflectance and transmittance](http://cie.co.at/publications/practical-methods-measurement-reflectance-and-transmittance). In less precise terms, the incidence angle on the sample surface is almost perpendicular.",
-              "type": "string",
-              "const": "nearnormal"
             }
           ]
         },

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -266,11 +266,11 @@
           "type": "object",
           "properties": {
             "polar": {
-              "$ref": "number.json#/$defs/degree",
+              "$ref": "number.json#/$defs/degreeWithUncertainty",
               "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has rotational symmetry, then the polar angle is sufficient to define the direction of incidence. If the sample has profile angle symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
             },
             "azimuth": {
-              "$ref": "number.json#/$defs/degree",
+              "$ref": "number.json#/$defs/degreeWithUncertainty",
               "description": "The direction of incidence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth is positive because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
             }
           },

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -262,24 +262,20 @@
       "description": "Direction of incident radiation on sample. An incidence angle of 10° or less as defined in the technical report [CIE 130-1998, Practical methods for the measurement of reflectance and transmittance](http://cie.co.at/publications/practical-methods-measurement-reflectance-and-transmittance) is called 'nearnormal' and said to be 'almost perpendicular'.",
       "oneOf": [
         {
-          "oneOf": [
-            {
-              "description": "Direction of incidence in a spherical coordinate system according to [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html).",
-              "type": "object",
-              "properties": {
-                "polar": {
-                  "$ref": "number.json#/$defs/degree",
-                  "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has rotational symmetry, then the polar angle is sufficient to define the direction of incidence. If the sample has profile angle symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
-                },
-                "azimuth": {
-                  "$ref": "number.json#/$defs/degree",
-                  "description": "The direction of incidence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth is positive because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
-                }
-              },
-              "additionalProperties": false,
-              "required": ["polar"]
+          "description": "Direction of incidence in a spherical coordinate system according to [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html).",
+          "type": "object",
+          "properties": {
+            "polar": {
+              "$ref": "number.json#/$defs/degree",
+              "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has rotational symmetry, then the polar angle is sufficient to define the direction of incidence. If the sample has profile angle symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
+            },
+            "azimuth": {
+              "$ref": "number.json#/$defs/degree",
+              "description": "The direction of incidence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth is positive because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
             }
-          ]
+          },
+          "additionalProperties": false,
+          "required": ["polar"]
         },
         {
           "title": "Hemispherical",

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -126,13 +126,16 @@
           "description": "Tilt angle, for example of venetian blinds."
         },
         "symmetries": {
-          "title": "Symmetries",
-          "description": "Symmetries of the optical characteristics. They reduce the necessary measurements and simulations.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/symmetry"
-          },
-          "minItems": 1
+          "title": "Choose between the general symmetries `mirror`, `rotationalDependingOnAzimuth` and `mirrorAndRotational` and their important special cases `azimuthalAngleInvariance` and `profileAngle`.",
+          "type": "string",
+          "enum": [
+            "azimuthalAngleInvariance",
+            "profileAngle",
+            "mirror",
+            "rotationalDependingOnAzimuth",
+            "mirrorAndRotational"
+          ],
+          "description": "(i) `azimuthalAngleInvariance` means that the optical results depend only on the polar angle and not on the azimuth angle. Many homogeneous materials like glass panes have an `azimuthalAngleInvariance`. (ii) `profileAngle` symmetry means the results are the same for all directions of incidence which have the same profile angle. The profile angle is the projection of the altitude angle of the incidence on a vertical plane which is perpendicular to the surface of the sample. (iii) In the case of a `mirror` symmetry, the results for one half of the possible directions of incidence are enough to determine also the results for the other half of the possible directions of incidence because the second half is a mirror image of the first half. However, if the optical results depend only on the profile angle, use `profileAngle` instead of `mirror`! (iv) `rotationalDependingOnAzimuth` means that for example one quarter of the hemisphere is enough to describe the whole hemisphere because the optical results for the other quarters can be obtained by rotating the results for the first quarter around the axis perpendicular to the sample. However, if the optical results depend only on the polar angle and not on the azimuth angle, use `azimuthalAngleInvariance` instead of `rotationalDependingOnAzimuth`! (v) `mirrorAndRotational` requires a mirror and a rotational symmetry. Mirror symmetry means that the results for one half of the possible directions of incidence are enough to determine also the results for the other half of the possible directions of incidence because the second half is a mirror image of the first half. Rotational symmetry means that for example one quarter of the hemisphere is enough to describe the whole hemisphere because the optical results for the other quarters can be obtained by rotating the results for the first quarter around the axis perpendicular to the sample. However, if the optical results depend only on the profile angle, use `profileAngle` instead of `mirrorAndRotational`! If the optical results depend only on the polar angle and not on the azimuth angle, use `azimuthalAngleInvariance` instead of `rotationalDependingOnAzimuth`!"
         },
         "definitionOfSurfacesAndPrimeDirection": {
           "title": "Definition of surfaces and prime direction",
@@ -163,12 +166,6 @@
       "additionalProperties": false,
       "minProperties": 1,
       "required": []
-    },
-    "symmetry": {
-      "type": "string",
-      "enum": ["incidenceAngle", "profileAngle", "mirror", "rotational"],
-      "title": "Symmetry",
-      "description": "(i) A component can have an optical symmetry regarding the angle of incidence. This means that the results are the same for all directions of incidence which have the same incidence angle. (ii) Accordingly, an optical symmetry regarding the profile angle means the results are the same for all directions of incidence which have the same profile angle. The profile angle is the projection of the altitude angle of the incidence on a vertical plane which is perpendicular to the surface of the sample. (iii) In the case of a mirror symmetry, the results for one half of the possible directions of incidence are enough to determine also the results for the other half of the possible directions of incidence because the second half is a mirror image of the first half. (iv) In the case of a rotational symmetry, the results for some directions of incidence are enough to determine the results for the other directions of incidence by rotating them around the line perpendicular to the surface of the component."
     },
     "polarization": {
       "title": "Polarization",
@@ -267,7 +264,7 @@
           "properties": {
             "polar": {
               "$ref": "number.json#/$defs/degreeWithUncertainty",
-              "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has incidence-angle symmetry, then the polar angle is sufficient to define the direction of incidence. If the sample has profile angle symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
+              "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has `azimuthalAngleInvariance`, then the optical results depend only on the polar angle and not on the azimuth angle. If the sample has a `profileAngle` symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
             },
             "azimuth": {
               "$ref": "number.json#/$defs/degreeWithUncertainty",
@@ -290,42 +287,20 @@
       "description": "Direction of radiation emerging from a sample either by transmission or reflection.",
       "oneOf": [
         {
-          "oneOf": [
-            {
-              "description": "Direction of emergence in a spherical coordinate system according to [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html).",
-              "type": "object",
-              "properties": {
-                "polar": {
-                  "$ref": "number.json#/$defs/degree",
-                  "description": "The polar angle is the angle between the direction of emergence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of emergence is perpendicular to the sample."
-                },
-                "azimuth": {
-                  "$ref": "number.json#/$defs/degree",
-                  "description": "The direction of emergence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth is positive because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
-                }
-              },
-              "additionalProperties": false,
-              "required": ["polar", "azimuth"]
+          "description": "Direction of emergence in a spherical coordinate system according to [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html).",
+          "type": "object",
+          "properties": {
+            "polar": {
+              "$ref": "number.json#/$defs/degree",
+              "description": "The polar angle is the angle between the direction of emergence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of emergence is perpendicular to the sample."
             },
-            {
-              "description": "If the sample has rotational symmetry, then the angle of reflectance is sufficient to define the direction of emergence.",
-              "type": "object",
-              "properties": {
-                "reflectance": {
-                  "$ref": "number.json#/$defs/degree",
-                  "title": "Reflectance angle"
-                }
-              },
-              "additionalProperties": false,
-              "required": ["reflectance"]
-            },
-            {
-              "title": "Nearnormal",
-              "description": "Emergence angle of 10° or less as defined in the technical report [CIE 130-1998, Practical methods for the measurement of reflectance and transmittance](http://cie.co.at/publications/practical-methods-measurement-reflectance-and-transmittance). In less precise terms, the emergence angle from the sample surface is almost perpendicular.",
-              "type": "string",
-              "const": "nearnormal"
+            "azimuth": {
+              "$ref": "number.json#/$defs/degree",
+              "description": "The direction of emergence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth is positive because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
             }
-          ]
+          },
+          "additionalProperties": false,
+          "required": ["polar", "azimuth"]
         },
         {
           "title": "Diffuse or hemispherical",

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -268,7 +268,7 @@
               "properties": {
                 "polar": {
                   "$ref": "number.json#/$defs/degree",
-                  "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample."
+                  "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has rotational symmetry, then the polar angle is sufficient to define the direction of incidence."
                 },
                 "azimuth": {
                   "$ref": "number.json#/$defs/degree",
@@ -276,19 +276,7 @@
                 }
               },
               "additionalProperties": false,
-              "required": ["polar", "azimuth"]
-            },
-            {
-              "description": "If the sample has rotational symmetry, then the incidence angle is sufficient to define the direction of incidence.",
-              "type": "object",
-              "properties": {
-                "incidence": {
-                  "$ref": "number.json#/$defs/degree",
-                  "title": "Incidence angle"
-                }
-              },
-              "additionalProperties": false,
-              "required": ["incidence"]
+              "required": ["polar"]
             },
             {
               "description": "If the sample has profile angle symmetry, then the profile angle is sufficient to define the direction. Assume a plane which is perpendicular to the surface of the sample and along the direction of the sample defined as prime. When you project the direction of incidence on that plane, then the profile angle is measured between this projection and the axis which is perpendicular to the surface. If the angle between the projection and the prime direction is smaller than 90°, then the profile angle is positive. If the projection is perpendicular to the surface, the profile angle equals 0°.",
@@ -305,7 +293,6 @@
             {
               "title": "Nearnormal",
               "description": "Incidence angle of 10° or less as defined in the technical report [CIE 130-1998, Practical methods for the measurement of reflectance and transmittance](http://cie.co.at/publications/practical-methods-measurement-reflectance-and-transmittance). In less precise terms, the incidence angle on the sample surface is almost perpendicular.",
-
               "type": "string",
               "const": "nearnormal"
             }

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -136,6 +136,7 @@
         },
         "definitionOfSurfacesAndPrimeDirection": {
           "title": "Definition of surfaces and prime direction",
+          "description": "The prime direction must be equal to the direction of the profile angle symmetry.",
           "type": "object",
           "properties": {
             "reference": {
@@ -268,7 +269,7 @@
               "properties": {
                 "polar": {
                   "$ref": "number.json#/$defs/degree",
-                  "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has rotational symmetry, then the polar angle is sufficient to define the direction of incidence."
+                  "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. If the sample has rotational symmetry, then the polar angle is sufficient to define the direction of incidence. If the sample has profile angle symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
                 },
                 "azimuth": {
                   "$ref": "number.json#/$defs/degree",
@@ -277,18 +278,6 @@
               },
               "additionalProperties": false,
               "required": ["polar"]
-            },
-            {
-              "description": "If the sample has profile angle symmetry, then the profile angle is sufficient to define the direction. Assume a plane which is perpendicular to the surface of the sample and along the direction of the sample defined as prime. When you project the direction of incidence on that plane, then the profile angle is measured between this projection and the axis which is perpendicular to the surface. If the angle between the projection and the prime direction is smaller than 90°, then the profile angle is positive. If the projection is perpendicular to the surface, the profile angle equals 0°.",
-              "type": "object",
-              "properties": {
-                "profile": {
-                  "$ref": "number.json#/$defs/degree",
-                  "title": "Profile angle"
-                }
-              },
-              "additionalProperties": false,
-              "required": ["profile"]
             },
             {
               "title": "Nearnormal",

--- a/schemas/photovoltaicData.json
+++ b/schemas/photovoltaicData.json
@@ -533,11 +533,10 @@
                   "minItems": 1
                 },
                 "angleDependency": {
-                  "title": "The nominal power usually depends on the direction of irradiance. In general, the `incidenceDirectionModifier` can characterize this dependency on the direction. If the dependency has a rotational symmetry regarding the incidence angle, `incidenceAngelModifier` should be provided.",
-                  "type": "object",
-                  "properties": {
-                    "incidenceAngleModifier": {
-                      "title": "If the nominal power has an incidence angle symmetry regarding the direct irradiance, then this Incidence Angle Modifier (IAM) can be defined and plotted as a curve. It modifies the nominal power depending on the incidence angle.",
+                  "title": "The nominal power usually depends on the direction of irradiance. In general, the `incidenceDirectionModifier` can characterize this dependency on the direction.  ",
+                  "oneOf": [
+                    {
+                      "title": "If the nominal power of the module depends only on the polar angle of the incidence and not on the azimuth angle (`azimuthalAngleInvariance`), then the Incidence Angle Modifier (IAM) should be defined here. It modifies the nominal power depending on the incidence angle.",
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -554,11 +553,10 @@
                           "minProperties": 1,
                           "required": []
                         }
-                      },
-                      "minItems": 1
+                      }
                     },
-                    "incidenceDirectionModifier": {
-                      "title": "If the nominal power depends on the direction of the irradiance, this modifier can be multiplied to the nominal power.",
+                    {
+                      "title": "If the nominal power depends on the azimuth angle of the incidence (no `azimuthalAngleInvariance`), then this section can be used to describe the dependency of the nominal power from the direction of incidence (Incidence Direction Modifier).",
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -574,13 +572,9 @@
                         },
                         "additionalProperties": false,
                         "required": ["direction", "modifier"]
-                      },
-                      "minItems": 1
+                      }
                     }
-                  },
-                  "additionalProperties": false,
-                  "minProperties": 1,
-                  "required": []
+                  ]
                 }
               },
               "additionalProperties": false,

--- a/tests/invalid/opticalData/wavelengthEmpty.json
+++ b/tests/invalid/opticalData/wavelengthEmpty.json
@@ -2,11 +2,17 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": { "wavelength": {} }
       },
       "emergence": {
-        "direction": "nearnormal"
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        }
       },
       "results": {
         "transmittance": {

--- a/tests/invalid/opticalData/wavelengthsEmpty.json
+++ b/tests/invalid/opticalData/wavelengthsEmpty.json
@@ -2,11 +2,17 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": {}
       },
       "emergence": {
-        "direction": "nearnormal"
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        }
       },
       "results": {
         "transmittance": {

--- a/tests/valid/opticalData/tree.json
+++ b/tests/valid/opticalData/tree.json
@@ -10,11 +10,17 @@
       "dataPoints": [
         {
           "incidence": {
-            "direction": "nearnormal",
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
             "wavelengths": { "integral": "solar" }
           },
           "emergence": {
-            "direction": "nearnormal"
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            }
           },
           "results": {
             "transmittance": {
@@ -36,11 +42,17 @@
           "dataPoints": [
             {
               "incidence": {
-                "direction": "nearnormal",
+                "direction": {
+                  "polar": 8,
+                  "azimuth": 0
+                },
                 "wavelengths": { "integral": "solar" }
               },
               "emergence": {
-                "direction": "nearnormal"
+                "direction": {
+                  "polar": 8,
+                  "azimuth": 0
+                }
               },
               "results": {
                 "transmittance": {
@@ -57,11 +69,17 @@
           "dataPoints": [
             {
               "incidence": {
-                "direction": "nearnormal",
+                "direction": {
+                  "polar": 8,
+                  "azimuth": 0
+                },
                 "wavelengths": { "integral": "solar" }
               },
               "emergence": {
-                "direction": "nearnormal"
+                "direction": {
+                  "polar": 8,
+                  "azimuth": 0
+                }
               },
               "results": {
                 "transmittance": {

--- a/tests/valid/opticalData/uncertainty/amplificationFactor.json
+++ b/tests/valid/opticalData/uncertainty/amplificationFactor.json
@@ -2,7 +2,10 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": {
           "wavelength": 500,
           "uncertainty": {
@@ -11,7 +14,10 @@
         }
       },
       "emergence": {
-        "direction": "nearnormal"
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        }
       },
       "results": {
         "transmittance": {

--- a/tests/valid/opticalData/uncertainty/bandwidth.json
+++ b/tests/valid/opticalData/uncertainty/bandwidth.json
@@ -2,7 +2,10 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": {
           "wavelength": 500,
           "uncertainty": {
@@ -11,7 +14,10 @@
         }
       },
       "emergence": {
-        "direction": "nearnormal"
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        }
       },
       "results": {
         "transmittance": {

--- a/tests/valid/opticalData/uncertainty/bandwidthAmplificationFactor.json
+++ b/tests/valid/opticalData/uncertainty/bandwidthAmplificationFactor.json
@@ -2,7 +2,10 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": {
           "wavelength": 500,
           "uncertainty": {
@@ -12,7 +15,10 @@
         }
       },
       "emergence": {
-        "direction": "nearnormal"
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        }
       },
       "results": {
         "transmittance": {

--- a/tests/valid/opticalData/wavelengths/integral.json
+++ b/tests/valid/opticalData/wavelengths/integral.json
@@ -2,11 +2,17 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": { "integral": "solar" }
       },
       "emergence": {
-        "direction": "nearnormal"
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        }
       },
       "results": {
         "transmittance": {

--- a/tests/valid/opticalData/wavelengths/single.json
+++ b/tests/valid/opticalData/wavelengths/single.json
@@ -2,13 +2,19 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": {
           "wavelength": 1
         }
       },
       "emergence": {
-        "direction": "nearnormal"
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        }
       },
       "results": {
         "transmittance": {

--- a/tests/valid/opticalData/wavelengths/singleShifted.json
+++ b/tests/valid/opticalData/wavelengths/singleShifted.json
@@ -2,13 +2,19 @@
   "dataPoints": [
     {
       "incidence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "wavelengths": {
           "wavelength": 500
         }
       },
       "emergence": {
-        "direction": "nearnormal",
+        "direction": {
+          "polar": 8,
+          "azimuth": 0
+        },
         "shiftedWavelengths": {
           "wavelength": 600
         }


### PR DESCRIPTION
`direction` and `symmetry` in `opticalData` were not clear enough. 

Therefore, we thought further about possible combinations and improved restrictions and updated the code accordingly.

Closes #96 