### PR TITLE
Move geometric information from `photovoltaicData` to `component`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at christoph.maurer@ise.fraunhofer.de. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json
+++ b/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json
@@ -5,7 +5,63 @@
         "value": "38dfed0a-2b9a-4748-8d98-e9d278cd12e4",
         "issuedBy": "ce588e6a-1d3c-4909-afdd-bcde4c33864e"
       },
-      "description": "A photovoltaic data set about one BIPV module of building N at Fraunhofer ISE, Freiburg, Germany.",
+      "description": "A photovoltaic data set about one BIPV module of building N at Fraunhofer ISE, Freiburg, Germany. (i) `characteristics/assemblyList` defines the thickness of the front cover, the front embedding, the PV cells, the rear embedding and the backing.",
+      "characteristics": {
+        "geometry": {
+          "assemblyList": [
+            {
+              "id": "01f5554f-e909-405e-9b7b-2f08ca201f63",
+              "geometry": {
+                "dimensions": {
+                  "independent": {
+                    "smallest": 0.0038,
+                    "intermediate": {
+                      "uncertainValue": 1.08,
+                      "uncertainty": 0.01
+                    },
+                    "largest": {
+                      "uncertainValue": 1.09,
+                      "uncertainty": 0.01
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "id": "02f5554f-e909-405e-9b7b-2f08ca201f63",
+              "geometry": {
+                "dimensions": {
+                  "independent": { "smallest": { "uncertainValue": 0.002 } }
+                }
+              }
+            },
+            {
+              "id": "03f5554f-e909-405e-9b7b-2f08ca201f63",
+              "geometry": {
+                "dimensions": {
+                  "independent": { "smallest": { "uncertainValue": 0.0004 } }
+                }
+              }
+            },
+            {
+              "id": "04f5554f-e909-405e-9b7b-2f08ca201f63",
+              "geometry": {
+                "dimensions": {
+                  "independent": { "smallest": { "uncertainValue": 0.002 } }
+                }
+              }
+            },
+            {
+              "id": "05f5554f-e909-405e-9b7b-2f08ca201f63",
+              "geometry": {
+                "dimensions": {
+                  "independent": { "smallest": { "uncertainValue": 0.002 } }
+                }
+              }
+            }
+          ]
+        }
+      },
       "photovoltaic": [
         {
           "data": [
@@ -93,71 +149,6 @@
                     "id2": {
                       "value": "764ca288-0c51-11ea-8d71-362b9e155667",
                       "issuedBy": "ce588e6a-1d3c-4909-afdd-bcde4c33864e"
-                    }
-                  }
-                ],
-                "moduleLayers": [
-                  {
-                    "identification": {
-                      "name": "Tempered white glass"
-                    },
-                    "categories": ["front", "cover"],
-                    "thickness": {
-                      "uncertainValue": 0.005
-                    },
-                    "geometry": {
-                      "dimensions": {
-                        "independent": {
-                          "smallest": {
-                            "uncertainValue": 0.005
-                          },
-                          "intermediate": {
-                            "uncertainValue": 1.08
-                          },
-                          "largest": {
-                            "uncertainValue": 1.09
-                          }
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "identification": {
-                      "name": "PVB"
-                    },
-                    "categories": ["front", "embedding"]
-                  },
-                  {
-                    "categories": ["cell"]
-                  },
-                  {
-                    "identification": {
-                      "name": "PVB"
-                    },
-                    "categories": ["rear", "embedding"]
-                  },
-                  {
-                    "identification": {
-                      "name": "Tempered white glass"
-                    },
-                    "categories": ["backing"],
-                    "thickness": {
-                      "uncertainValue": 0.004
-                    },
-                    "geometry": {
-                      "dimensions": {
-                        "independent": {
-                          "smallest": {
-                            "uncertainValue": 0.004
-                          },
-                          "intermediate": {
-                            "uncertainValue": 1.08
-                          },
-                          "largest": {
-                            "uncertainValue": 1.09
-                          }
-                        }
-                      }
                     }
                   }
                 ],

--- a/schemas/photovoltaicData.json
+++ b/schemas/photovoltaicData.json
@@ -293,61 +293,6 @@
           "$ref": "#/$defs/connections/$defs/bidirectional",
           "description": "The connections between cells and between cells and diodes."
         },
-        "moduleLayers": {
-          "title": "Photovoltaic modules typically consist of several layers, for example a glass pane, a lamination material and the photovoltaic cells.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "identification": {
-                "$ref": "material.json#/$defs/identification",
-                "description": "The material of the layer"
-              },
-              "characteristics": {
-                "$ref": "material.json#/$defs/characteristics",
-                "description": "All properties which depend on the material in general and not on the specific component."
-              },
-              "categories": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "backing",
-                    "cell",
-                    "cover",
-                    "embedding",
-                    "front",
-                    "rear"
-                  ],
-                  "description": "Typically, a photovoltaic module consists of a front cover layer, a front embedding layer, a cell layer, a rear embedding layer and a backing layer. The layer can therefore be defined by multiple strings."
-                },
-                "uniqueItems": true,
-                "minItems": 1,
-                "maxItems": 2
-              },
-              "thickness": {
-                "$ref": "number.json#/$defs/meterWithUncertainty",
-                "description": "The thickness of this layer as part of the module."
-              },
-              "weight": {
-                "$ref": "number.json#/$defs/kilogramWithUncertainty",
-                "description": "The weigth of the layer."
-              },
-              "geometry": {
-                "$ref": "geometry.json",
-                "description": "The geometry and location of the layer including its dimensions."
-              },
-              "colour": {
-                "$ref": "common.json#/$defs/colour",
-                "description": "The reference offers several way to define the colour of the component."
-              }
-            },
-            "additionalProperties": false,
-            "minProperties": 1,
-            "required": []
-          },
-          "minItems": 1
-        },
         "electricConfiguration": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
It's a problem that [moduleLayers](https://github.com/ise621/building-envelope-data/blob/9e0b3056b3732b1054bf6bf72d595683df81701c/schemas/photovoltaicData.json#L296) contained geometric information. Therefore, I deleted it so that all geometric information is handled at the level of component/characteristics/[geometry](https://github.com/ise621/building-envelope-data/blob/9e0b3056b3732b1054bf6bf72d595683df81701c/schemas/component.json#L230). 

I updated the example bipvModuleBuildingNatIse.json accordingly. It know uses assemblyList/geometry/[dimensions](https://github.com/ise621/building-envelope-data/blob/0d7f4990e06e063cc6e01fe59f61020efea5bce7/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json#L15) to define the thickness of the layers of the PV module. Further information about the layers can be requested with their [id](https://github.com/ise621/building-envelope-data/blob/0d7f4990e06e063cc6e01fe59f61020efea5bce7/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json#L13).

Closes #109

I removed `moduleLayers` from photovoltaicData.json, because the assembly is better described by `components/characteristics/geometry/assemblyList`. 
