### PR TITLE
Add examples for IGSDB data

### DIFF
--- a/tests/invalid/opticalData/igsdbExample01inputData.json
+++ b/tests/invalid/opticalData/igsdbExample01inputData.json
@@ -1,0 +1,91 @@
+{
+  "product_id": 363,
+  "name": "Generic Clear Glass",
+  "nfrc_id": 102,
+  "igdb_database_version": "11.4",
+  "cgdb_shading_layer_id": null,
+  "cgdb_database_version": null,
+  "acceptance": "#",
+  "appearance": "Clear",
+  "manufacturer_name": "Generic",
+  "data_file_name": "CLEAR_3.DAT",
+  "data_file_available": false,
+  "short_description": null,
+  "type": "glazing",
+  "subtype": "monolithic",
+  "deconstructable": false,
+  "coating_name": "N/A",
+  "coated_side": "Neither",
+  "measured_data": {
+    "is_specular": true,
+    "thickness": 3.04800009727478,
+    "tir_front": 0.0,
+    "tir_back": null,
+    "emissivity_front": 0.839999973773956,
+    "emissivity_back": 0.839999973773956,
+    "conductivity": 1.0,
+    "permeability_factor": null
+  },
+  "integrated_results_summary": [
+    {
+      "calculation_standard_name": "NFRC",
+      "tfsol": 0.8338478,
+      "tbsol": null,
+      "rfsol": 0.07476376,
+      "rbsol": 0.07485449,
+      "tfvis": 0.89926,
+      "tbvis": null,
+      "rfvis": 0.08256317,
+      "rbvis": 0.08256352,
+      "tdw": 0.8416837,
+      "tuv": 0.7145357,
+      "tspf": 10.8546,
+      "tkr": null,
+      "tciex": 84.75503,
+      "tciey": 89.94103,
+      "tciez": 96.27183,
+      "tf_r": null,
+      "tf_g": null,
+      "tf_b": null,
+      "rfciex": 7.777915,
+      "rfciey": 8.269908,
+      "rfciez": 9.109017,
+      "rf_r": null,
+      "rf_g": null,
+      "rf_b": null,
+      "rbciex": null,
+      "rbciey": null,
+      "rbciez": null,
+      "rb_r": null,
+      "rb_g": null,
+      "rb_b": null
+    }
+  ],
+  "spectral_data": {
+    "spectral_data": [
+      {
+        "T": 0.0020000000949949,
+        "Rb": 0.0480000004172325,
+        "Rf": 0.0469999983906746,
+        "wavelength": 0.3
+      },
+      {
+        "T": 0.762000024318695,
+        "Rb": 0.0670000016689301,
+        "Rf": 0.0659999996423721,
+        "wavelength": 1.0
+      },
+      {
+        "T": 0.822000026702881,
+        "Rb": 0.068000003695488,
+        "Rf": 0.068000003695488,
+        "wavelength": 2.5
+      }
+    ],
+    "dual_band_values": {}
+  },
+  "igdb_checksum": -1717699038,
+  "cgdb_shade_material_id": null,
+  "cgdb_checksum": null,
+  "composition": []
+}

--- a/tests/valid/opticalData/igsdbExample0101.json
+++ b/tests/valid/opticalData/igsdbExample0101.json
@@ -1,0 +1,138 @@
+{
+  "data": [
+    {
+      "componentCharacteristics": {
+        "surface": "prime"
+      },
+      "dataPoints": [
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": { "wavelength": 300 }
+          },
+          "emergence": {
+            "direction": "hemispherical"
+          },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.002
+            },
+            "reflectance": {
+              "uncertainValue": 0.047
+            }
+          }
+        },
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": { "wavelength": 1000 }
+          },
+          "emergence": {
+            "direction": "hemispherical"
+          },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.003
+            },
+            "reflectance": {
+              "uncertainValue": 0.047
+            }
+          }
+        },
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": { "wavelength": 2500 }
+          },
+          "emergence": {
+            "direction": "hemispherical"
+          },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.009
+            },
+            "reflectance": {
+              "uncertainValue": 0.047
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentCharacteristics": {
+        "surface": "nonPrime"
+      },
+      "dataPoints": [
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": { "wavelength": 300 }
+          },
+          "emergence": {
+            "direction": "hemispherical"
+          },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.002
+            },
+            "reflectance": {
+              "uncertainValue": 0.047
+            }
+          }
+        },
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": { "wavelength": 1000 }
+          },
+          "emergence": {
+            "direction": "hemispherical"
+          },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.003
+            },
+            "reflectance": {
+              "uncertainValue": 0.047
+            }
+          }
+        },
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": { "wavelength": 2500 }
+          },
+          "emergence": {
+            "direction": "hemispherical"
+          },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.009
+            },
+            "reflectance": {
+              "uncertainValue": 0.047
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/valid/opticalData/igsdbExample0102.json
+++ b/tests/valid/opticalData/igsdbExample0102.json
@@ -1,0 +1,58 @@
+{
+  "data": [
+    {
+      "componentCharacteristics": {
+        "surface": "prime"
+      },
+      "dataPoints": [
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": {
+              "integral": "solar"
+            }
+          },
+          "emergence": { "direction": "hemispherical" },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.834
+            },
+            "reflectance": {
+              "uncertainValue": 0.075
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentCharacteristics": {
+        "surface": "nonPrime"
+      },
+      "dataPoints": [
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": {
+              "integral": "solar"
+            }
+          },
+          "emergence": { "direction": "hemispherical" },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.834
+            },
+            "reflectance": {
+              "uncertainValue": 0.075
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Call https://igsdb.lbl.gov/api/v1/products/363/ and store the data in igsdbExample01inputData.json in the LBNL format. Create igsdbExample0101.json and igsdbExample0102.json to illustrate how the data can be returned according to https://www.buildingenvelopedata.org/schemas/v1/opticalData.json .

Relates to #186