### PR TITLE
Extend the examples of opticalData from IGSDB

### DIFF
--- a/tests/valid/opticalData/igsdbExample0102.json
+++ b/tests/valid/opticalData/igsdbExample0102.json
@@ -24,6 +24,26 @@
               "uncertainValue": 0.075
             }
           }
+        },
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": {
+              "integral": "visible"
+            }
+          },
+          "emergence": { "direction": "hemispherical" },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.834
+            },
+            "reflectance": {
+              "uncertainValue": 0.075
+            }
+          }
         }
       ]
     },
@@ -40,6 +60,26 @@
             },
             "wavelengths": {
               "integral": "solar"
+            }
+          },
+          "emergence": { "direction": "hemispherical" },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0.834
+            },
+            "reflectance": {
+              "uncertainValue": 0.075
+            }
+          }
+        },
+        {
+          "incidence": {
+            "direction": {
+              "polar": 8,
+              "azimuth": 0
+            },
+            "wavelengths": {
+              "integral": "visible"
             }
           },
           "emergence": { "direction": "hemispherical" },

--- a/tests/valid/opticalData/igsdbExample0103.json
+++ b/tests/valid/opticalData/igsdbExample0103.json
@@ -1,0 +1,52 @@
+{
+  "data": [
+    {
+      "componentCharacteristics": {
+        "surface": "prime"
+      },
+      "dataPoints": [
+        {
+          "incidence": {
+            "direction": "hemispherical",
+            "wavelengths": {
+              "integral": "infrared"
+            }
+          },
+          "emergence": { "direction": "hemispherical" },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0
+            },
+            "reflectance": {
+              "uncertainValue": 0.16
+            }
+          }
+        }
+      ]
+    },
+    {
+      "componentCharacteristics": {
+        "surface": "nonPrime"
+      },
+      "dataPoints": [
+        {
+          "incidence": {
+            "direction": "hemispherical",
+            "wavelengths": {
+              "integral": "infrared"
+            }
+          },
+          "emergence": { "direction": "hemispherical" },
+          "results": {
+            "transmittance": {
+              "uncertainValue": 0
+            },
+            "reflectance": {
+              "uncertainValue": 0.16
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add igsdbExample0103.json for infrared values. Add `visible` values to
igsdbExample0102.json. Keep the three data sets 0101-0103 separate,
because they are created by separate methods.