### PR TITLE
Add more examples for polarization

### DIFF
--- a/tests/valid/opticalData/polarization/equallySandPpolarized.json
+++ b/tests/valid/opticalData/polarization/equallySandPpolarized.json
@@ -1,0 +1,25 @@
+{
+  "dataPoints": [
+    {
+      "incidence": {
+        "direction": {
+          "polar": 60,
+          "azimuth": 0
+        },
+        "wavelengths": { "integral": "solar" },
+        "polarization": {
+          "s": 0.5,
+          "p": 0.5
+        }
+      },
+      "emergence": {
+        "direction": "hemispherical"
+      },
+      "results": {
+        "transmittance": {
+          "uncertainValue": 0.1
+        }
+      }
+    }
+  ]
+}

--- a/tests/valid/opticalData/polarization/polarizationUnknown.json
+++ b/tests/valid/opticalData/polarization/polarizationUnknown.json
@@ -1,0 +1,21 @@
+{
+  "dataPoints": [
+    {
+      "incidence": {
+        "direction": {
+          "polar": 60,
+          "azimuth": 0
+        },
+        "wavelengths": { "integral": "solar" }
+      },
+      "emergence": {
+        "direction": "hemispherical"
+      },
+      "results": {
+        "transmittance": {
+          "uncertainValue": 0.1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
If the radiation is equally s and p polarized, it is defined like
equallySandPpolarized.json. If the polarization is unknown, the key is
omitted as in polarizationUnknown.json.