### PR TITLE
Add roughness and clean-up geometry.json

### DIFF
--- a/schemas/component.json
+++ b/schemas/component.json
@@ -393,6 +393,46 @@
           "uniqueItems": true,
           "description": "In this array, the most important chemical elements can be named by the two letters of the periodic table of elements."
         },
+        "definitionOfSurfacesAndPrimeDirection": {
+          "title": "Definition of surfaces and prime direction",
+          "description": "The prime direction must be equal to the direction of the profile angle symmetry.",
+          "type": "object",
+          "properties": {
+            "reference": {
+              "$ref": "common.json#/$defs/reference",
+              "title": "Reference",
+              "description": "Reference that defines which surface of the component is defined as non-prime and which as prime. Often, the non-prime surface faces the exterior and the prime surface faces the interior. The reference should also define a prime direction which is used to calculate the azimuth of the direction of incidence. Ideally, the manufacturer defines the surfaces and prime direction of a component in one document and refers to this document in optical data."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "Description of which side of the component is defined as non-prime and which as prime, and which side is top and which side is bottom. Often, the non-prime side faces the exterior and the prime side the interior."
+            }
+          },
+          "minProperties": 1,
+          "required": []
+        },
+        "roughness": {
+          "title": "Definition of the roughness of the prime surfaces and the non-prime surface.Both are defined by `definitionOfSurfacesAndPrimeDirection`.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "surface": {
+                "$ref": "#/$defs/surface",
+                "description": "Definition of the surface for which the roughness is defined in this item."
+              },
+              "root-mean-square": {
+                "$ref": "number.json#/$defs/numberWithUncertainty",
+                "description": "The root-mean-square roughness is calculated according to ISO 4287:2010, Section 4.2.2 as the root-mean-square of the roughness profile."
+              }
+            },
+            "minProperties": 1,
+            "required": ["surface", "root-mean-square"]
+          },
+          "minItems": 1,
+          "description": "Each item of the array defines a surface of the component together with the roughness of this surface."
+        },
         "material": {
           "$ref": "material.json#/$defs/characteristics",
           "description": "If the component is a material, the material-specific characteristics can be named here."
@@ -469,6 +509,12 @@
       "additionalProperties": false,
       "minProperties": 1,
       "required": ["assemblyList"]
+    },
+    "surface": {
+      "type": "string",
+      "enum": ["nonPrime", "prime", "symmetric"],
+      "title": "Surface",
+      "description": "Whether the incidence is on the non-prime or the prime surface of the sample. Both are defined in `definitionOfSurfacesAndPrimeDirection`. If the results are identical for both sides, 'symmetric' can be used."
     }
   },
   "$ref": "#/$defs/component"

--- a/schemas/geometry.json
+++ b/schemas/geometry.json
@@ -5,13 +5,9 @@
   "description": "Describe geoemtry data. There are many highly developed geometry kernels which are well suited to handle complex geometry in their file format. For some cases like the shape of a venetian blind, it may be helpful to be able to exchange the geometry independent of a geometry kernel.",
   "$defs": {
     "geometry": {
-      "title": "Describe the geometry of a component.",
+      "title": "Describe the geometry of a component either by its outer dimensions or as a resource for a Computer Aided Drawing (CAD) software.",
       "type": "object",
       "properties": {
-        "centerOfGravity": {
-          "$ref": "#/$defs/point",
-          "description": "Definition of the center of gravity of the component"
-        },
         "dimensions": {
           "$ref": "#/$defs/dimensions",
           "description": "Height, width and depth of the component."
@@ -19,14 +15,6 @@
         "coordinateSystem": {
           "$ref": "#/$defs/coordinateSystem",
           "description": "Definition of the coordinate systems to which the other coordinates refer to."
-        },
-        "bodies": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/body"
-          },
-          "minItems": 1,
-          "description": "This array lists all the bodies of which the component consists."
         },
         "getHttpsResource": {
           "$ref": "common.json#/$defs/getHttpsResource",

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -137,29 +137,8 @@
           ],
           "description": "(i) `azimuthalAngleInvariance` means that the optical results depend only on the polar angle and not on the azimuth angle. Many homogeneous materials like glass panes have an `azimuthalAngleInvariance`. (ii) `profileAngle` symmetry means the results are the same for all directions of incidence which have the same profile angle. The profile angle is the projection of the altitude angle of the incidence on a vertical plane which is perpendicular to the surface of the sample. (iii) In the case of a `mirror` symmetry, the results for one half of the possible directions of incidence are enough to determine also the results for the other half of the possible directions of incidence because the second half is a mirror image of the first half. However, if the optical results depend only on the profile angle, use `profileAngle` instead of `mirror`! (iv) `rotationalDependingOnAzimuth` means that for example one quarter of the hemisphere is enough to describe the whole hemisphere because the optical results for the other quarters can be obtained by rotating the results for the first quarter around the axis perpendicular to the sample. However, if the optical results depend only on the polar angle and not on the azimuth angle, use `azimuthalAngleInvariance` instead of `rotationalDependingOnAzimuth`! (v) `mirrorAndRotational` requires a mirror and a rotational symmetry. Mirror symmetry means that the results for one half of the possible directions of incidence are enough to determine also the results for the other half of the possible directions of incidence because the second half is a mirror image of the first half. Rotational symmetry means that for example one quarter of the hemisphere is enough to describe the whole hemisphere because the optical results for the other quarters can be obtained by rotating the results for the first quarter around the axis perpendicular to the sample. However, if the optical results depend only on the profile angle, use `profileAngle` instead of `mirrorAndRotational`! If the optical results depend only on the polar angle and not on the azimuth angle, use `azimuthalAngleInvariance` instead of `rotationalDependingOnAzimuth`!"
         },
-        "definitionOfSurfacesAndPrimeDirection": {
-          "title": "Definition of surfaces and prime direction",
-          "description": "The prime direction must be equal to the direction of the profile angle symmetry.",
-          "type": "object",
-          "properties": {
-            "reference": {
-              "$ref": "common.json#/$defs/reference",
-              "title": "Reference",
-              "description": "Reference that defines which surface of the component is defined as non-prime and which as prime. Often, the non-prime surface faces the exterior and the prime surface faces the interior. The reference should also define a prime direction which is used to calculate the azimuth of the direction of incidence. Ideally, the manufacturer defines the surfaces and prime direction of a component in one document and refers to this document in optical data."
-            },
-            "description": {
-              "type": "string",
-              "title": "Description",
-              "description": "Description of which side of the component is defined as non-prime and which as prime, and which side is top and which side is bottom. Often, the non-prime side faces the exterior and the prime side the interior."
-            }
-          },
-          "minProperties": 1,
-          "required": []
-        },
         "surface": {
-          "type": "string",
-          "enum": ["nonPrime", "prime", "symmetric"],
-          "title": "Surface",
+          "$ref": "component.json#/$defs/surface",
           "description": "Whether the incidence is on the non-prime or the prime surface of the sample. Both are defined in `definitionOfSurfacesAndPrimeDirection`. If the results are identical for both sides, 'symmetric' can be used."
         }
       },


### PR DESCRIPTION
I have deleted `centerOfGravity`, because it is only helpful in a CAD
software.

I have deleted `bodies`, because this can be covered by `assembly`.

I have moved `definitionOfSurfacesAndPrimeDirection` from
opticalData.json to component.json#/$defs/characteristics, because it's
needed to define the roughness and possibly other properties beyond the
scope of opticalData.json.

I have added roughness/root-mean-square to component.json, because it
may be relevant beyond the scope of opticalData.json.

I moved the definition of `surface` to component.json because it is
needed there and can be referenced by opticalData.json.

Closes #204