### PR TITLE
Add example photovoltaicWithOptical.json

### DIFF
--- a/examples/dbe/photovoltaic/photovoltaicWithOptical.json
+++ b/examples/dbe/photovoltaic/photovoltaicWithOptical.json
@@ -1,0 +1,297 @@
+{
+  "components": [
+    {
+      "id": "22aaed0a-2b9a-4748-8d98-e9d278cd12e4",
+      "description": "This example represents a double glazing with photovoltaic cells in the laminated glass pane facing the exterior. It includes optical properties which are needed for raytracing simulations.",
+      "relations": {
+        "concretizationOf": "11aaed0a-2b9a-4748-8d98-e9d278cd12e4",
+        "assembledOf": [
+          "20aaed0a-2b9a-4748-8d98-e9d278cd12e4",
+          "18A16000-2b9a-4748-8d98-e9d278cd12e4",
+          "66abed0a-2b9a-4748-8d98-e9d278cd12e4"
+        ]
+      },
+      "categories": { "componentType": ["unit"] },
+      "characteristics": {
+        "geometry": {
+          "dimensions": {
+            "independent": {
+              "smallest": 0.415,
+              "intermediate": 1.109,
+              "largest": 2.488
+            }
+          },
+          "getHttpsResource": {
+            "hashValue": "38A529341DC538879E61DEE1F95F40FD4A91D1D74C32C1206448DB95F0EBE6BE",
+            "locator": "https://oc.ise.fraunhofer.de/index.php/s/w9uW4Veh4fWyF5w",
+            "format": { "id": "409b7fa3-2b9a-4748-8d98-e9d278cd12e4" },
+            "archivedFilesMetaInformation": []
+          }
+        },
+        "definitionOfSurfacesAndPrimeDirection": {
+          "description": "The prime surface faces the interior of the building and the nonPrime surface faces the exterior."
+        },
+        "roughness": [
+          {
+            "surface": "nonPrime",
+            "rootMeanSquare": 0.2
+          }
+        ]
+      },
+      "optical": [
+        {
+          "id": {
+            "value": "a8435146-5270-46f5-b925-4b00de265823",
+            "issuedBy": "ce588e6a-1d3c-4909-afdd-bcde4c33864e"
+          },
+          "description": "Example: Nearnormal-nearnormal reflectance for red, green and blue and nearnormal-hemispherical transmittance for red, green and blue.",
+          "data": [
+            {
+              "dataPoints": [
+                {
+                  "incidence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
+                    "wavelengths": { "wavelength": 430 }
+                  },
+                  "emergence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    }
+                  },
+                  "results": {
+                    "reflectance": {
+                      "uncertainValue": 0.1
+                    }
+                  }
+                },
+                {
+                  "incidence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
+                    "wavelengths": { "wavelength": 540 }
+                  },
+                  "emergence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    }
+                  },
+                  "results": {
+                    "reflectance": {
+                      "uncertainValue": 0.1
+                    }
+                  }
+                },
+                {
+                  "incidence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
+                    "wavelengths": { "wavelength": 570 }
+                  },
+                  "emergence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    }
+                  },
+                  "results": {
+                    "reflectance": {
+                      "uncertainValue": 0.1
+                    }
+                  }
+                },
+                {
+                  "incidence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
+                    "wavelengths": { "wavelength": 430 }
+                  },
+                  "emergence": {
+                    "direction": "hemispherical"
+                  },
+                  "results": {
+                    "reflectance": {
+                      "uncertainValue": 0.1
+                    }
+                  }
+                },
+                {
+                  "incidence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
+                    "wavelengths": { "wavelength": 540 }
+                  },
+                  "emergence": {
+                    "direction": "hemispherical"
+                  },
+                  "results": {
+                    "reflectance": {
+                      "uncertainValue": 0.1
+                    }
+                  }
+                },
+                {
+                  "incidence": {
+                    "direction": {
+                      "polar": 8,
+                      "azimuth": 0
+                    },
+                    "wavelengths": { "wavelength": 570 }
+                  },
+                  "emergence": {
+                    "direction": "hemispherical"
+                  },
+                  "results": {
+                    "reflectance": {
+                      "uncertainValue": 0.1
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "calorimetric": [
+        {
+          "data": [
+            {
+              "results": [
+                {
+                  "area": { "category": "outerDimensions" },
+                  "uValue": 1.23,
+                  "gValue": { "uncertainValue": 0.5, "uncertainty": 0.1 }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "photovoltaic": [
+        {
+          "data": [
+            {
+              "module": {
+                "cellTypes": [
+                  {
+                    "id": "b0d2b769-74d8-46ab-a3b7-16bb52ac4c60",
+
+                    "width": {
+                      "uncertainValue": 0.156
+                    },
+                    "categories": ["monocrystalline", "silicon"]
+                  }
+                ],
+                "cellPattern": {
+                  "rectangular": {
+                    "longitudinal": {
+                      "cellNumber": {
+                        "uncertainValue": 10
+                      }
+                    },
+                    "transversal": {
+                      "cellNumber": {
+                        "uncertainValue": 6
+                      }
+                    }
+                  }
+                },
+                "cells": [
+                  {
+                    "id": {
+                      "value": "764ca288-0c51-11ea-8d71-362b9e155667",
+                      "issuedBy": "ce588e6a-1d3c-4909-afdd-bcde4c33864e"
+                    },
+                    "cellType": {
+                      "value": "b0d2b769-74d8-46ab-a3b7-16bb52ac4c60",
+                      "issuedBy": "ce588e6a-1d3c-4909-afdd-bcde4c33864e"
+                    }
+                  },
+                  {
+                    "id": {
+                      "value": "764ca508-0c51-11ea-8d71-362b9e155667",
+                      "issuedBy": "ce588e6a-1d3c-4909-afdd-bcde4c33864e"
+                    },
+                    "cellType": {
+                      "value": "b0d2b769-74d8-46ab-a3b7-16bb52ac4c60",
+                      "issuedBy": "ce588e6a-1d3c-4909-afdd-bcde4c33864e"
+                    }
+                  }
+                ],
+
+                "connectionPattern": "series",
+
+                "electricConfiguration": {
+                  "junctionBoxTypes": [
+                    {
+                      "id": "6a5083af-7bee-491c-b3fd-d6229f6a56ec"
+                    }
+                  ],
+
+                  "connectorTypes": [
+                    {
+                      "id": "7c43b619-402f-4309-b66f-5672b8ca071d"
+                    }
+                  ],
+                  "connectors": [
+                    {
+                      "id": "14838e0b-e17b-4c52-8578-fb2cc9170ac4",
+                      "connectorType": "411249fc-14c7-4940-805b-15dc0855b444",
+                      "junctionBoxType": "538a6419-aecd-45c1-8e61-8dd4d3e74988"
+                    }
+                  ],
+                  "groundingNecessary": false
+                },
+                "moduleProperties": {
+                  "power": {
+                    "nominal": {
+                      "uncertainValue": 260
+                    },
+                    "temperatureCoefficient": -0.32,
+                    "guarantees": [
+                      {
+                        "years": 10,
+                        "percentage": 90
+                      },
+                      {
+                        "years": 15,
+                        "percentage": 80
+                      }
+                    ],
+                    "angleDependency": [
+                      {
+                        "incidence": 0,
+                        "IAM": 1
+                      },
+                      {
+                        "incidence": 60,
+                        "IAM": 0.924
+                      },
+                      {
+                        "incidence": 90,
+                        "IAM": 0
+                      }
+                    ]
+                  },
+                  "efficiency": 0.1656
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/component.json
+++ b/schemas/component.json
@@ -422,13 +422,13 @@
                 "$ref": "#/$defs/surface",
                 "description": "Definition of the surface for which the roughness is defined in this item."
               },
-              "root-mean-square": {
+              "rootMeanSquare": {
                 "$ref": "number.json#/$defs/numberWithUncertainty",
                 "description": "The root-mean-square roughness is calculated according to ISO 4287:2010, Section 4.2.2 as the root-mean-square of the roughness profile."
               }
             },
-            "minProperties": 1,
-            "required": ["surface", "root-mean-square"]
+            "minProperties": 2,
+            "required": ["surface", "rootMeanSquare"]
           },
           "minItems": 1,
           "description": "Each item of the array defines a surface of the component together with the roughness of this surface."


### PR DESCRIPTION
In addition to data of a BIPV module, photovoltaicWithOptical.json
includes optical data which is needed for raytracing simulations with
Radiance.

I changed "root-mean-square" to "rootMeanSquare" for consistency.