### PR TITLE
Delete meaningless `azimuth`=0

### DIFF
--- a/examples/dbe/allDomains/semitransparentBuildingIntegratedPhotovoltaicThermal.json
+++ b/examples/dbe/allDomains/semitransparentBuildingIntegratedPhotovoltaicThermal.json
@@ -15,8 +15,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },
@@ -64,8 +63,7 @@
                       "uncertainValue": 1000
                     },
                     "direction": {
-                      "polar": 0,
-                      "azimuth": 0
+                      "polar": 0
                     }
                   },
                   {
@@ -74,8 +72,7 @@
                       "uncertainValue": -500
                     },
                     "direction": {
-                      "polar": 0,
-                      "azimuth": 0
+                      "polar": 0
                     }
                   }
                 ],

--- a/examples/dbe/calorimetric/bistMeasurement.json
+++ b/examples/dbe/calorimetric/bistMeasurement.json
@@ -40,6 +40,14 @@
           "validity": {
             "from": "2018-08-01T00:00:00+01:00"
           },
+          "characteristics": {
+            "geometry": {
+              "dimensions": { "installed": [{ "depth": 0.00023 }] }
+            },
+            "definitionOfSurfacesAndPrimeDirection": {
+              "description": "The prime surface faces the interior of the building and the nonPrime surface faces the exterior. The prime direction is indicated by a label on the sample. Facing the installed component from the exterior, the prime direction directs to the right-hand side."
+            }
+          },
           "data": [
             {
               "fluxes": {
@@ -70,8 +78,8 @@
                       "confidenceInterval": 68.3
                     },
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 60,
+                      "azimuth": 90
                     }
                   }
                 ],

--- a/examples/dbe/koester.json
+++ b/examples/dbe/koester.json
@@ -16,8 +16,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": {
                       "integral": "visible"

--- a/examples/dbe/optical/es-sda-example0101layer.json
+++ b/examples/dbe/optical/es-sda-example0101layer.json
@@ -36,8 +36,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "infrared" }
                   },
@@ -56,15 +55,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 280 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -79,8 +76,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 280 }
                   },
@@ -99,15 +95,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 285 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -122,8 +116,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 285 }
                   },
@@ -158,8 +151,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "infrared" }
                   },
@@ -178,15 +170,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 280 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -201,8 +191,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 280 }
                   },
@@ -221,15 +210,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 285 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -244,8 +231,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 285 }
                   },

--- a/examples/dbe/optical/es-sda-example0102unit.json
+++ b/examples/dbe/optical/es-sda-example0102unit.json
@@ -38,8 +38,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },
@@ -58,15 +57,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -78,8 +75,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "visible" }
                   },
@@ -98,8 +94,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "visible" }
                   },
@@ -131,8 +126,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },

--- a/examples/dbe/optical/nearnormalHemisphericalSolarReflectanceAccordingToStandard.json
+++ b/examples/dbe/optical/nearnormalHemisphericalSolarReflectanceAccordingToStandard.json
@@ -30,8 +30,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },

--- a/examples/dbe/optical/nearnormalHemisphericalVisibleTransmittance.json
+++ b/examples/dbe/optical/nearnormalHemisphericalVisibleTransmittance.json
@@ -15,8 +15,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "visible" }
                   },

--- a/examples/dbe/optical/nearnormalNearnormalSpectrallyResolvedTransmittance.json
+++ b/examples/dbe/optical/nearnormalNearnormalSpectrallyResolvedTransmittance.json
@@ -15,15 +15,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 500 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -35,15 +33,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 1000 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -55,15 +51,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 1500 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {

--- a/examples/dbe/optical/polarization/sPolarizedTransmittance.json
+++ b/examples/dbe/optical/polarization/sPolarizedTransmittance.json
@@ -15,8 +15,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 60,
-                      "azimuth": 0
+                      "polar": 60
                     },
                     "wavelengths": { "integral": "solar" },
                     "polarization": { "s": 0.2, "p": 0.8 }

--- a/examples/dbe/origin/methodAccordingToStandard.json
+++ b/examples/dbe/origin/methodAccordingToStandard.json
@@ -30,8 +30,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },

--- a/examples/dbe/origin/methodAsAservice.json
+++ b/examples/dbe/origin/methodAsAservice.json
@@ -45,8 +45,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },

--- a/examples/dbe/origin/originMethodAccordingToStandard.json
+++ b/examples/dbe/origin/originMethodAccordingToStandard.json
@@ -45,8 +45,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "integral": "solar" }
                   },

--- a/examples/dbe/photovoltaic/photovoltaicWithOptical.json
+++ b/examples/dbe/photovoltaic/photovoltaicWithOptical.json
@@ -51,15 +51,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 430 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -71,15 +69,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 540 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -91,15 +87,13 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 570 }
                   },
                   "emergence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     }
                   },
                   "results": {
@@ -111,8 +105,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 430 }
                   },
@@ -128,8 +121,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 540 }
                   },
@@ -145,8 +137,7 @@
                 {
                   "incidence": {
                     "direction": {
-                      "polar": 8,
-                      "azimuth": 0
+                      "polar": 8
                     },
                     "wavelengths": { "wavelength": 570 }
                   },

--- a/tests/invalid/opticalData/polarization/notEnumPolarization.json
+++ b/tests/invalid/opticalData/polarization/notEnumPolarization.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 60,
-          "azimuth": 0
+          "polar": 60
         },
         "wavelengths": { "integral": "solar" },
         "polarization": "l"

--- a/tests/invalid/opticalData/wavelengthEmpty.json
+++ b/tests/invalid/opticalData/wavelengthEmpty.json
@@ -3,15 +3,13 @@
     {
       "incidence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         },
         "wavelengths": { "wavelength": {} }
       },
       "emergence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         }
       },
       "results": {

--- a/tests/invalid/opticalData/wavelengthsEmpty.json
+++ b/tests/invalid/opticalData/wavelengthsEmpty.json
@@ -3,15 +3,13 @@
     {
       "incidence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         },
         "wavelengths": {}
       },
       "emergence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         }
       },
       "results": {

--- a/tests/valid/opticalData/igsdbExample0101.json
+++ b/tests/valid/opticalData/igsdbExample0101.json
@@ -8,8 +8,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": { "wavelength": 300 }
           },
@@ -28,8 +27,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": { "wavelength": 1000 }
           },
@@ -48,8 +46,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": { "wavelength": 2500 }
           },
@@ -75,8 +72,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": { "wavelength": 300 }
           },
@@ -95,8 +91,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": { "wavelength": 1000 }
           },
@@ -115,8 +110,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": { "wavelength": 2500 }
           },

--- a/tests/valid/opticalData/igsdbExample0102.json
+++ b/tests/valid/opticalData/igsdbExample0102.json
@@ -8,8 +8,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": {
               "integral": "solar"
@@ -28,8 +27,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": {
               "integral": "visible"
@@ -55,8 +53,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": {
               "integral": "solar"
@@ -75,8 +72,7 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": {
               "integral": "visible"

--- a/tests/valid/opticalData/polarization/equallySandPpolarized.json
+++ b/tests/valid/opticalData/polarization/equallySandPpolarized.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 60,
-          "azimuth": 0
+          "polar": 60
         },
         "wavelengths": { "integral": "solar" },
         "polarization": {

--- a/tests/valid/opticalData/polarization/lPolarized.json
+++ b/tests/valid/opticalData/polarization/lPolarized.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 60,
-          "azimuth": 0
+          "polar": 60
         },
         "wavelengths": { "integral": "solar" },
         "polarization": "leftHanded"

--- a/tests/valid/opticalData/polarization/polarizationUnknown.json
+++ b/tests/valid/opticalData/polarization/polarizationUnknown.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 60,
-          "azimuth": 0
+          "polar": 60
         },
         "wavelengths": { "integral": "solar" }
       },

--- a/tests/valid/opticalData/polarization/rPolarized.json
+++ b/tests/valid/opticalData/polarization/rPolarized.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 60,
-          "azimuth": 0
+          "polar": 60
         },
         "wavelengths": { "integral": "solar" },
         "polarization": "rightHanded"

--- a/tests/valid/opticalData/tree.json
+++ b/tests/valid/opticalData/tree.json
@@ -11,15 +11,13 @@
         {
           "incidence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             },
             "wavelengths": { "integral": "solar" }
           },
           "emergence": {
             "direction": {
-              "polar": 8,
-              "azimuth": 0
+              "polar": 8
             }
           },
           "results": {
@@ -43,15 +41,13 @@
             {
               "incidence": {
                 "direction": {
-                  "polar": 8,
-                  "azimuth": 0
+                  "polar": 8
                 },
                 "wavelengths": { "integral": "solar" }
               },
               "emergence": {
                 "direction": {
-                  "polar": 8,
-                  "azimuth": 0
+                  "polar": 8
                 }
               },
               "results": {
@@ -70,15 +66,13 @@
             {
               "incidence": {
                 "direction": {
-                  "polar": 8,
-                  "azimuth": 0
+                  "polar": 8
                 },
                 "wavelengths": { "integral": "solar" }
               },
               "emergence": {
                 "direction": {
-                  "polar": 8,
-                  "azimuth": 0
+                  "polar": 8
                 }
               },
               "results": {

--- a/tests/valid/opticalData/uncertainty/amplificationFactor.json
+++ b/tests/valid/opticalData/uncertainty/amplificationFactor.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         },
         "wavelengths": {
           "wavelength": 500,
@@ -15,8 +14,7 @@
       },
       "emergence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         }
       },
       "results": {

--- a/tests/valid/opticalData/uncertainty/bandwidth.json
+++ b/tests/valid/opticalData/uncertainty/bandwidth.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         },
         "wavelengths": {
           "wavelength": 500,
@@ -15,8 +14,7 @@
       },
       "emergence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         }
       },
       "results": {

--- a/tests/valid/opticalData/uncertainty/bandwidthAmplificationFactor.json
+++ b/tests/valid/opticalData/uncertainty/bandwidthAmplificationFactor.json
@@ -3,8 +3,7 @@
     {
       "incidence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         },
         "wavelengths": {
           "wavelength": 500,
@@ -16,8 +15,7 @@
       },
       "emergence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         }
       },
       "results": {

--- a/tests/valid/opticalData/wavelengths/integral.json
+++ b/tests/valid/opticalData/wavelengths/integral.json
@@ -3,15 +3,13 @@
     {
       "incidence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         },
         "wavelengths": { "integral": "solar" }
       },
       "emergence": {
         "direction": {
-          "polar": 8,
-          "azimuth": 0
+          "polar": 8
         }
       },
       "results": {

--- a/tests/valid/opticalData/wavelengths/single.json
+++ b/tests/valid/opticalData/wavelengths/single.json
@@ -4,7 +4,7 @@
       "incidence": {
         "direction": {
           "polar": 8,
-          "azimuth": 0
+          "azimuth": 90
         },
         "wavelengths": {
           "wavelength": 1
@@ -13,7 +13,7 @@
       "emergence": {
         "direction": {
           "polar": 8,
-          "azimuth": 0
+          "azimuth": 90
         }
       },
       "results": {


### PR DESCRIPTION
I used regex ,\n\s+"azimuth": 0 to delete `azimuth`=0 because it has no
meaning. Examples with `azimuth`=!0 remain.