### PR TITLE
Offer detailed definition of calorimetric fluxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to
 - Improve the structure of geometry.json [#205](https://github.com/ise621/building-envelope-data/pull/205)
 - Improve the structure of calorimetricData.json [#209](https://github.com/ise621/building-envelope-data/pull/209)]
 - Correct the requirements of `emergenceDirection`[#213](https://github.com/ise621/building-envelope-data/pull/213)
+- Offer detailed definition of calorimetric fluxes [#222](https://github.com/ise621/building-envelope-data/pull/222)
 -
 
 ### Deprecated

--- a/designGoals.md
+++ b/designGoals.md
@@ -1,7 +1,7 @@
 The API specification is mainly intended for software developers. It is being developed with the following design goals:
 
 1. Facilitate re-use of the data schemas by keeping them modular.
-1. Facilitate automated use by minimizing the number of valid variants.
-1. Enable representation of all optical and calorimetric data which is currently relevant for building performance simulation.
+1. Facilitate automated use by minimizing the number of valid representations of data.
+1. Enable representation of all optical and calorimetric data which is currently relevant for building performance simulation and product characterization.
 1. The meaning of a valid data set will be unambiguous.
 1. The API should enable efficient data exchange.

--- a/examples/dbe/allDomains/semitransparentBuildingIntegratedPhotovoltaicThermal.json
+++ b/examples/dbe/allDomains/semitransparentBuildingIntegratedPhotovoltaicThermal.json
@@ -40,7 +40,7 @@
           "data": [
             {
               "fluxes": {
-                "convection": [
+                "mixed": [
                   {
                     "side": "exterior",
                     "flux": 0
@@ -50,7 +50,7 @@
                     "flux": 0
                   }
                 ],
-                "irradiance": [
+                "shortwaveRadiation": [
                   {
                     "side": "exterior",
                     "flux": 1000,

--- a/examples/dbe/calorimetric/bistMeasurement.json
+++ b/examples/dbe/calorimetric/bistMeasurement.json
@@ -47,22 +47,22 @@
           "createdAt": "2018-09-01T12:00:00+01:00",
           "data": [
             {
+              "characteristics": {
+                "conditions": "stationary",
+                "primeSurface": "interior"
+              },
               "fluxes": {
-                "convection": [
+                "mixed": [
                   {
                     "side": "interior",
                     "flux": {
                       "uncertainValue": 15.0,
                       "uncertainty": 4,
                       "confidenceInterval": 95.4
-                    },
-                    "temperatures": {
-                      "surrounding": 298.0
-                    },
-                    "coefficient": 8.0
+                    }
                   }
                 ],
-                "irradiance": [
+                "shortwaveRadiation": [
                   {
                     "side": "exterior",
                     "flux": {

--- a/schemas/calorimetricData.json
+++ b/schemas/calorimetricData.json
@@ -41,9 +41,9 @@
           "enum": ["dynamic", "stationary"],
           "description": "Either a measurement aims at quasi-stationary conditions or at dynamic conditions where the values change over time."
         },
-        "coordinateSystem": {
-          "$ref": "geometry.json#/$defs/coordinateSystem",
-          "description": "The coordinate system is defined by a reference to a publication or standard."
+        "primeSurface": {
+          "$ref": "#/$defs/side",
+          "description": "This subschema defines the orientation of the prime surface. The prime surface is defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`."
         }
       },
       "additionalProperties": false,
@@ -52,6 +52,47 @@
     "fluxes": {
       "type": "object",
       "properties": {
+        "conduction": {
+          "title": "Conductive heat transfer is defined by the temperature difference and the heat transfer coefficient.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "side": {
+                "$ref": "#/$defs/side",
+                "description": "The side which is considered for this conduction."
+              },
+              "flux": {
+                "$ref": "number.json#/$defs/wattWithUncertainty",
+                "description": "The heat flux is driven by the temperature differences. Positive heat flux means heat flux towards the sample. It is measured in watts."
+              },
+              "temperatures": {
+                "type": "object",
+                "properties": {
+                  "surrounding": {
+                    "$ref": "number.json#/$defs/kelvinWithUncertainty",
+                    "description": "The average temperature of this part of the surroundings."
+                  },
+                  "sample": {
+                    "$ref": "number.json#/$defs/kelvinWithUncertainty",
+                    "description": "The average temperature of the part of the sample which faces this part of the surroundings."
+                  }
+                },
+                "additionalProperties": false,
+                "minProperties": 1,
+                "required": []
+              },
+              "coefficient": {
+                "$ref": "number.json#/$defs/wattPerSquareMeterKelvinWithUncertainty",
+                "description": "The heat transfer coefficient equals the heat flux divided by the temperature difference. It has the unit watt per square meter per kelvin."
+              }
+            },
+            "additionalProperties": false,
+            "minProperties": 1,
+            "required": []
+          },
+          "minItems": 1
+        },
         "convection": {
           "title": "Convective heat transfer is defined by the temperature difference and the heat transfer coefficient.",
           "type": "array",
@@ -93,7 +134,90 @@
           },
           "minItems": 1
         },
-        "irradiance": {
+        "longwaveRadiation": {
+          "title": "Due to their temperature, bodies emit thermal radiation. Therefore, bodies with different temperatures can exchange heat by this infrared radiation. The wavelength of this radiation is longer than the wavelengths of the solar spectrum. It is therfore called long-wave radiation.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "side": {
+                "$ref": "#/$defs/side",
+                "description": "The side which is considered for this radiative heat transfer."
+              },
+              "flux": {
+                "$ref": "number.json#/$defs/wattWithUncertainty",
+                "description": "The heat flux is driven by the temperature differences. Positive heat flux means heat flux towards the sample. It is measured in watts."
+              },
+              "temperatures": {
+                "type": "object",
+                "properties": {
+                  "surrounding": {
+                    "$ref": "number.json#/$defs/kelvinWithUncertainty",
+                    "description": "The average temperature of this part of the surroundings."
+                  },
+                  "sample": {
+                    "$ref": "number.json#/$defs/kelvinWithUncertainty",
+                    "description": "The average temperature of the part of the sample which faces this part of the surroundings."
+                  }
+                },
+                "additionalProperties": false,
+                "minProperties": 1,
+                "required": []
+              },
+              "emittanceSurroundings": {
+                "$ref": "number.json#/$defs/numberBetweenZeroAndOneWithUncertainty",
+                "description": "The emittance of the surroundings influences the radiative heat transfer. The emittance of the surface of the sample can be defined within `opticalData`. Emittances have no units."
+              }
+            },
+            "additionalProperties": false,
+            "minProperties": 1,
+            "required": []
+          },
+          "minItems": 1
+        },
+        "conductionConvectionLongwaveRadiation": {
+          "title": "Heat transfer by conduction, convection and long-wave radiation can be treated together.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "side": {
+                "$ref": "#/$defs/side",
+                "description": "The side which is considered for this combined heat transfer."
+              },
+              "flux": {
+                "$ref": "number.json#/$defs/wattWithUncertainty",
+                "description": "The heat flux is driven by the temperature differences. Positive heat flux means heat flux towards the sample. It is measured in watts."
+              },
+              "temperatures": {
+                "type": "object",
+                "properties": {
+                  "surrounding": {
+                    "$ref": "number.json#/$defs/kelvinWithUncertainty",
+                    "description": "The average temperature of this part of the surroundings."
+                  },
+                  "sample": {
+                    "$ref": "number.json#/$defs/kelvinWithUncertainty",
+                    "description": "The average temperature of the part of the sample which faces this part of the surroundings."
+                  }
+                },
+                "additionalProperties": false,
+                "minProperties": 1,
+                "required": []
+              },
+              "coefficient": {
+                "$ref": "number.json#/$defs/wattPerSquareMeterKelvinWithUncertainty",
+                "description": "The heat transfer coefficient equals the heat flux divided by the temperature difference. It has the unit watt per square meter per kelvin."
+              }
+            },
+            "additionalProperties": false,
+            "minProperties": 1,
+            "required": []
+          },
+          "minItems": 1
+        },
+        "shortwaveRadiation": {
+          "title": "Shortwave radiation has similar wavelengths as the visible and the solar spectrum. These wavelenghts are shorter than the wavelengths of `longwaveRadiation`.",
           "type": "array",
           "items": {
             "type": "object",
@@ -109,6 +233,27 @@
               "direction": {
                 "$ref": "opticalData.json#/$defs/incidenceDirection",
                 "description": "The direction of the irradiance on the sample."
+              }
+            },
+            "additionalProperties": false,
+            "minProperties": 1,
+            "required": []
+          },
+          "minItems": 1
+        },
+        "mixed": {
+          "title": "Heat transfer can be a mixture of other forms of heat transfer. It can be characterized by the energy flux towards the sample.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "side": {
+                "$ref": "#/$defs/side",
+                "description": "The side which is considered for the mixed heat transfer."
+              },
+              "flux": {
+                "$ref": "number.json#/$defs/wattWithUncertainty",
+                "description": "The heat flux is driven by the temperature differences. Positive heat flux means heat flux towards the sample. It is measured in watts."
               }
             },
             "additionalProperties": false,

--- a/tests/valid/calorimetricData/characteristics.json
+++ b/tests/valid/calorimetricData/characteristics.json
@@ -1,0 +1,6 @@
+{
+  "characteristics": {
+    "conditions": "stationary",
+    "primeSurface": "interior"
+  }
+}

--- a/tests/valid/calorimetricData/fluxes.json
+++ b/tests/valid/calorimetricData/fluxes.json
@@ -1,0 +1,84 @@
+{
+  "fluxes": {
+    "conduction": [
+      {
+        "side": "lateral",
+        "flux": 1,
+        "temperatures": {
+          "surrounding": 301,
+          "sample": 300
+        },
+        "coefficient": 1
+      }
+    ],
+    "convection": [
+      {
+        "side": "exterior",
+        "flux": 10,
+        "temperatures": {
+          "surrounding": 301,
+          "sample": 300
+        },
+        "coefficient": 10
+      }
+    ],
+    "longwaveRadiation": [
+      {
+        "side": "exterior",
+        "flux": 1,
+        "temperatures": {
+          "surrounding": 301,
+          "sample": 300
+        }
+      }
+    ],
+    "conductionConvectionLongwaveRadiation": [
+      {
+        "side": "exterior",
+        "flux": 10,
+        "temperatures": {
+          "surrounding": 301,
+          "sample": 300
+        },
+        "coefficient": 10
+      }
+    ],
+    "mixed": [
+      {
+        "side": "interior",
+        "flux": 10
+      }
+    ],
+    "shortwaveRadiation": [
+      {
+        "side": "exterior",
+        "flux": 1000,
+        "direction": {
+          "polar": 60,
+          "azimuth": 90
+        }
+      }
+    ],
+    "fluid": [
+      {
+        "flux": 100,
+        "temperatures": {
+          "inlet": 300,
+          "outlet": 320
+        },
+        "massFlow": 0.02,
+        "specificHeatCapacity": 4179.6
+      }
+    ],
+    "electricity": [
+      {
+        "flux": 10,
+        "currentVoltage": [
+          { "I": 0, "V": 1 },
+          { "I": 0.5, "V": 0.5 },
+          { "I": 1, "V": 0 }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/valid/calorimetricData/results.json
+++ b/tests/valid/calorimetricData/results.json
@@ -1,0 +1,15 @@
+{
+  "results": [
+    {
+      "area": {
+        "category": "centre"
+      },
+      "uValue": 1,
+      "gValue": 1,
+      "efficiencies": {
+        "solarThermal": 0.5,
+        "photovoltaic": 0.1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I have added heat exchange by conduction, by long-wave heat transfer, by combination of conduction, convection and long-wave heat transfer and by mixed heat transfer.

With `primeSurface`, there is now a way to define the orientation of the installed sample. This is needed to retrieve the emittance of the sample.

I have deleted characteristics/coordinateSystem, because it is not needed anymore. The definition of the prime surface and prime direction in `component` is sufficient to define the direction of the irradiance.

I have updated the examples and added tests.

I have slightly improved the wording of the designGoals.md .