### PR TITLE
Add PDF as example `dataFormat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ and this project adheres to
 - Add section to publication to be able to refer to just one part of a publication [#155](https://github.com/ise621/building-envelope-data/pull/155)
 - Add two examples of methods for daylighting and glare simulations [#179](https://github.com/ise621/building-envelope-data/pull/179)
 - Add version to JSON Schema `$id`s [#188](https://github.com/ise621/building-envelope-data/pull/188)
-- Add examples [#207](https://github.com/ise621/building-envelope-data/pull/207), [#209](https://github.com/ise621/building-envelope-data/pull/209), [#213](https://github.com/ise621/building-envelope-data/pull/213)
+- Add examples photovoltaicWithOptical [#207](https://github.com/ise621/building-envelope-data/pull/207), semitransparentBuildingIntegratedPhotovoltaicThermal [#209](https://github.com/ise621/building-envelope-data/pull/209), from ES-SDA [#213](https://github.com/ise621/building-envelope-data/pull/213) and dataFormatPdf [#226](https://github.com/ise621/building-envelope-data/pull/226)
 - Add the key `roughness` [#205](https://github.com/ise621/building-envelope-data/pull/205)
 - Add the position of coatings to components [#223](https://github.com/ise621/building-envelope-data/pull/223)
--
+- Add `currentVoltage` characteristics for modules [#224](https://github.com/ise621/building-envelope-data/pull/224)
 -
 -
 -
@@ -61,7 +61,7 @@ and this project adheres to
 - Improve the structure of calorimetricData.json [#209](https://github.com/ise621/building-envelope-data/pull/209)]
 - Correct the requirements of `emergenceDirection`[#213](https://github.com/ise621/building-envelope-data/pull/213)
 - Offer detailed definition of calorimetric fluxes [#222](https://github.com/ise621/building-envelope-data/pull/222)
-- Add categories from EN 12216 to the categories of `layer` and `unit` [#223](https://github.com/ise621/building-envelope-data/pull/223)
+- Add categories to `material`, `layer` and `unit` from EN 12216 [#223](https://github.com/ise621/building-envelope-data/pull/223) and from EN 13024-1, EN 14179, EN 1863, DIN 18008-5 [#224](https://github.com/ise621/building-envelope-data/pull/224)
 -
 
 ### Deprecated

--- a/examples/dbe/getHttpsResource/dataFormatPdf.json
+++ b/examples/dbe/getHttpsResource/dataFormatPdf.json
@@ -1,0 +1,33 @@
+{
+  "components": [
+    {
+      "id": "22aaed0a-2b9a-4748-8d98-e9d278cd12e4",
+      "description": "This example represents the dataFormat PDF used to describe the geometry of a component.",
+      "characteristics": {
+        "geometry": {
+          "getHttpsResource": {
+            "hashValue": "A1C529341DC538879E61DEE1F95F40FD4A91D1D74C32C1206448DB95F0EBE6BE",
+            "locator": "https://oc.ise.fraunhofer.de/index.php/s/w9uW4Veh4fWyF1c",
+            "format": {
+              "id": "c3306b72-2c4f-4c91-af89-aaeefdba1730",
+              "timestamp": "2019-09-01T12:00:00+01:00",
+              "name": "Portable Document Format (PDF)",
+              "abbreviation": "PDF",
+              "description": "Portable Document Format (PDF), standardized as ISO 32000, is a file format developed by Adobe in 1993 to present documents, including text formatting and images, in a manner independent of application software, hardware, and operating systems.",
+              "reference": {
+                "standard": {
+                  "standardizers": ["ISO"],
+                  "numeration": {
+                    "mainNumber": 32000
+                  }
+                }
+              },
+              "mediaType": "application/pdf"
+            },
+            "archivedFilesMetaInformation": []
+          }
+        }
+      }
+    }
+  ]
+}

--- a/examples/dbe/photovoltaic/bipvModuleSunovationGlazingUnit.json
+++ b/examples/dbe/photovoltaic/bipvModuleSunovationGlazingUnit.json
@@ -24,7 +24,7 @@
           "getHttpsResource": {
             "hashValue": "38A529341DC538879E61DEE1F95F40FD4A91D1D74C32C1206448DB95F0EBE6BE",
             "locator": "https://oc.ise.fraunhofer.de/index.php/s/w9uW4Veh4fWyF5w",
-            "format": { "id": "409b7fa3-2b9a-4748-8d98-e9d278cd12e4" },
+            "format": { "id": "c3306b72-2c4f-4c91-af89-aaeefdba1730" },
             "archivedFilesMetaInformation": []
           }
         }


### PR DESCRIPTION
I have added dataFormatPdf.json as an example of a data format, in this
case PDF.

I have substituted the formatId in bipvModuleSunovationGlazingUnit.json
by the uuid representing PDF.

Closes #166.