### PR TITLE
Allow geometric assemblies of collector fields

### DIFF
--- a/apis/metabase.graphql
+++ b/apis/metabase.graphql
@@ -1,3 +1,90 @@
+"""
+Read-only GraphQL schema for the [metabase](https://www.buildingenvelopedata.org/graphql/) of the network of databases for [building envelope data](https://www.buildingenvelopedata.org). While the metabase stores meta information for example about components and institutions, the (child) databases store the data about building envelope components.
+
+It follows best practices for
+* [Global Object Identification](https://graphql.org/learn/global-object-identification/)
+  as exemplified in
+  [GraphQL Server Specification: Object Identification](https://relay.dev/docs/en/graphql-server-specification.html#object-identification)
+  (see also [GraphQL Global Object Identification Specification](https://relay.dev/graphql/objectidentification.htm)),
+  and
+* [Pagination](https://graphql.org/learn/pagination/),
+  by adhering to the
+  [GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm),
+  as exemplified in
+  [GraphQL Server Specification: Connections](https://relay.dev/docs/en/graphql-server-specification.html#connections).
+
+Global object identifiers as requird by the best practice are exposed by the
+property `id` and universally unique identifiers as issued by the "metabase"
+are exposed by the property `uuid`. In essence, `id` is the Base64-encoded
+concatenation of `uuid` and the requested locale.
+
+For interoperability with the (child) databases, implementations serve HTTP
+requests as elaborated on
+[Serving over HTTP](https://graphql.org/learn/serving-over-http/).
+
+The
+[Internet Engineering Task Force (IETF)](https://www.ietf.org)
+is an Internet standards organization. It publishes standards in
+[Request for Comments (RFC)](https://ietf.org/standards/rfcs/)
+documents. They are
+[searchable](https://www.rfc-editor.org/search/rfc_search.php)
+and
+[indexed](https://www.rfc-editor.org/rfc-index.html).
+Examples are
+[Hypertext Transfer Protocol (HTTP)](https://tools.ietf.org/html/rfc7231)
+and
+[Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc8446).
+
+The
+[Internet Assigned Numbers Authority (IANA)](https://www.iana.org)
+allocates and maintains unique codes and numbering systems that are used in
+technical standards that drive the Internet like
+[domain names](https://www.iana.org/domains),
+[Internet Protocol addresses](https://www.iana.org/numbers), and
+[registries](https://www.iana.org/protocols).
+Examples of the last are
+[HTTP status code registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+and
+[media type registry](https://www.iana.org/assignments/media-types/media-types.xhtml).
+
+The
+[International Organization for Standardization (ISO)](https://www.iso.org)
+develops and publishes
+[International Standards](https://www.iso.org/standards-catalogue/browse-by-ics.html).
+Examples are
+[ISO 8601 Date And Time Format](https://www.iso.org/iso-8601-date-and-time-format.html)
+and
+[ISO 3166 Country Codes](https://www.iso.org/iso-3166-country-codes.html).
+
+The library
+[graphql-scalars](https://github.com/Urigo/graphql-scalars)
+introduces custom scalar types for creating precise type-safe GraphQL schemas.
+We took some inspiration from
+[GitHub GraphQL API](https://docs.github.com/en/graphql).
+"""
+scalar Schema
+
+"""
+[RFC 4122](https://tools.ietf.org/html/rfc4122)
+compliant
+[non-nil](https://tools.ietf.org/html/rfc4122#section-4.1.7)
+[Universally Unique Identifier (UUID)](https://tools.ietf.org/html/rfc4122#section-4.1)
+string represented as 32 hexadecimal digits in five groups separated by hyphens
+in the form `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`, like
+`"936da01f-9abd-4d9d-80c7-02af85c822a8"`. Such identifiers are not equal to
+`"00000000-0000-0000-0000-000000000000"` and match the regular expression
+`^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$`.
+"""
+scalar Uuid
+
+"""
+[GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm)
+compliant
+[Cursor](https://relay.dev/graphql/connections.htm#sec-Cursor)
+string.
+"""
+scalar Cursor
+
 schema {
   query: Query
   mutation: Mutation
@@ -70,6 +157,7 @@ type CalorimetricData implements Data {
 type CalorimetricDataConnection {
   edges: [CalorimetricDataEdge!]!
   nodes: [CalorimetricData!]!
+  pageInfo: PageInfo!
   timestamp: DateTime!
   totalCount: NonNegativeInt
 }
@@ -145,6 +233,7 @@ type ComponentEdge {
 
 type ComponentManufacturerConnection {
   edges: [ComponentManufacturerEdge!]!
+  pageInfo: PageInfo!
 }
 
 type ComponentManufacturerEdge {
@@ -288,6 +377,7 @@ type DataApproval {
 type DataConnection {
   edges: [DataEdge!]!
   nodes: [Data!]!
+  pageInfo: PageInfo!
   timestamp: DateTime!
   totalCount: NonNegativeInt
 }
@@ -333,26 +423,98 @@ type DataFormatManagerEdge {
 }
 
 type Database implements Node {
-  allCalorimetricData(after: String before: String first: NonNegativeInt last: NonNegativeInt locale: String timestamp: DateTime where: CalorimetricDataPropositionInput!): CalorimetricDataConnection
-  allData(after: String before: String first: NonNegativeInt last: NonNegativeInt locale: String timestamp: DateTime where: DataPropositionInput!): DataConnection
-  allHygrothermalData(after: String before: String first: NonNegativeInt last: NonNegativeInt locale: String timestamp: DateTime where: HygrothermalDataPropositionInput!): HygrothermalDataConnection
-  allOpticalData(after: String before: String first: NonNegativeInt last: NonNegativeInt locale: String timestamp: DateTime where: OpticalDataPropositionInput!): OpticalDataConnection
-  allPhotovoltaicData(after: String before: String first: NonNegativeInt last: NonNegativeInt locale: String timestamp: DateTime where: PhotovoltaicDataPropositionInput!): PhotovoltaicDataConnection
-  calorimetricData(id: Uuid! locale: String timestamp: DateTime): CalorimetricData
-  data(id: Uuid! locale: String timestamp: DateTime): Data
+  allCalorimetricData(
+    after: String
+    before: String
+    first: NonNegativeInt
+    last: NonNegativeInt
+    locale: String
+    timestamp: DateTime
+    where: CalorimetricDataPropositionInput!
+  ): CalorimetricDataConnection
+  allData(
+    after: String
+    before: String
+    first: NonNegativeInt
+    last: NonNegativeInt
+    locale: String
+    timestamp: DateTime
+    where: DataPropositionInput!
+  ): DataConnection
+  allHygrothermalData(
+    after: String
+    before: String
+    first: NonNegativeInt
+    last: NonNegativeInt
+    locale: String
+    timestamp: DateTime
+    where: HygrothermalDataPropositionInput!
+  ): HygrothermalDataConnection
+  allOpticalData(
+    after: String
+    before: String
+    first: NonNegativeInt
+    last: NonNegativeInt
+    locale: String
+    timestamp: DateTime
+    where: OpticalDataPropositionInput!
+  ): OpticalDataConnection
+  allPhotovoltaicData(
+    after: String
+    before: String
+    first: NonNegativeInt
+    last: NonNegativeInt
+    locale: String
+    timestamp: DateTime
+    where: PhotovoltaicDataPropositionInput!
+  ): PhotovoltaicDataConnection
+  calorimetricData(
+    id: Uuid!
+    locale: String
+    timestamp: DateTime
+  ): CalorimetricData
+  data(id: Uuid!, locale: String, timestamp: DateTime): Data
   description: String!
-  hasCalorimetricData(locale: String timestamp: DateTime where: CalorimetricDataPropositionInput!): Boolean
-  hasData(locale: String timestamp: DateTime where: DataPropositionInput!): Boolean
-  hasHygrothermalData(locale: String timestamp: DateTime where: HygrothermalDataPropositionInput!): Boolean
-  hasOpticalData(locale: String timestamp: DateTime where: OpticalDataPropositionInput!): Boolean
-  hasPhotovoltaicData(locale: String timestamp: DateTime where: PhotovoltaicDataPropositionInput!): Boolean
-  hygrothermalData(id: Uuid! locale: String timestamp: DateTime): HygrothermalData
+  hasCalorimetricData(
+    locale: String
+    timestamp: DateTime
+    where: CalorimetricDataPropositionInput!
+  ): Boolean
+  hasData(
+    locale: String
+    timestamp: DateTime
+    where: DataPropositionInput!
+  ): Boolean
+  hasHygrothermalData(
+    locale: String
+    timestamp: DateTime
+    where: HygrothermalDataPropositionInput!
+  ): Boolean
+  hasOpticalData(
+    locale: String
+    timestamp: DateTime
+    where: OpticalDataPropositionInput!
+  ): Boolean
+  hasPhotovoltaicData(
+    locale: String
+    timestamp: DateTime
+    where: PhotovoltaicDataPropositionInput!
+  ): Boolean
+  hygrothermalData(
+    id: Uuid!
+    locale: String
+    timestamp: DateTime
+  ): HygrothermalData
   id: ID!
   locator: Url!
   name: String!
   operator: DatabaseOperatorEdge!
-  opticalData(id: Uuid! locale: String timestamp: DateTime): OpticalData
-  photovoltaicData(id: Uuid! locale: String timestamp: DateTime): PhotovoltaicData
+  opticalData(id: Uuid!, locale: String, timestamp: DateTime): OpticalData
+  photovoltaicData(
+    id: Uuid!
+    locale: String
+    timestamp: DateTime
+  ): PhotovoltaicData
   uuid: Uuid!
 }
 
@@ -507,6 +669,7 @@ type HygrothermalData implements Data {
 type HygrothermalDataConnection {
   edges: [HygrothermalDataEdge!]!
   nodes: [HygrothermalData!]!
+  pageInfo: PageInfo!
   timestamp: DateTime!
   totalCount: NonNegativeInt
 }
@@ -519,17 +682,23 @@ type HygrothermalDataEdge {
 type Institution implements Node & Stakeholder {
   abbreviation: String
   description: String!
-  developedMethods(pending: Boolean! = false): InstitutionDevelopedMethodConnection!
+  developedMethods(
+    pending: Boolean! = false
+  ): InstitutionDevelopedMethodConnection!
   id: ID!
   managedDataFormats: InstitutionManagedDataFormatConnection!
   managedInstitutions: InstitutionManagedInstitutionConnection!
   managedMethods: InstitutionManagedMethodConnection!
   manager: InstitutionManagerEdge
-  manufacturedComponents(pending: Boolean! = false): InstitutionManufacturedComponentConnection!
+  manufacturedComponents(
+    pending: Boolean! = false
+  ): InstitutionManufacturedComponentConnection!
   name: String!
   operatedDatabases: InstitutionOperatedDatabaseConnection!
   publicKey: String
-  representatives(pending: Boolean! = false): InstitutionRepresentativeConnection!
+  representatives(
+    pending: Boolean! = false
+  ): InstitutionRepresentativeConnection!
   state: InstitutionState!
   uuid: Uuid!
   websiteLocator: Url
@@ -549,6 +718,7 @@ type InstitutionConnection {
 type InstitutionDevelopedMethodConnection {
   canCurrentUserConfirmEdge: Boolean!
   edges: [InstitutionDevelopedMethodEdge!]!
+  pageInfo: PageInfo!
 }
 
 type InstitutionDevelopedMethodEdge {
@@ -566,6 +736,7 @@ type InstitutionEdge {
 type InstitutionManagedDataFormatConnection {
   canCurrentUserAddEdge: Boolean!
   edges: [InstitutionManagedDataFormatEdge!]!
+  pageInfo: PageInfo!
 }
 
 type InstitutionManagedDataFormatEdge {
@@ -575,6 +746,7 @@ type InstitutionManagedDataFormatEdge {
 type InstitutionManagedInstitutionConnection {
   canCurrentUserAddEdge: Boolean!
   edges: [InstitutionManagedInstitutionEdge!]!
+  pageInfo: PageInfo!
 }
 
 type InstitutionManagedInstitutionEdge {
@@ -584,6 +756,7 @@ type InstitutionManagedInstitutionEdge {
 type InstitutionManagedMethodConnection {
   canCurrentUserAddEdge: Boolean!
   edges: [InstitutionManagedMethodEdge!]!
+  pageInfo: PageInfo!
 }
 
 type InstitutionManagedMethodEdge {
@@ -598,6 +771,7 @@ type InstitutionManufacturedComponentConnection {
   canCurrentUserAddEdge: Boolean!
   canCurrentUserConfirmEdge: Boolean!
   edges: [InstitutionManufacturedComponentEdge!]!
+  pageInfo: PageInfo!
 }
 
 type InstitutionManufacturedComponentEdge {
@@ -611,6 +785,7 @@ type InstitutionMethodDeveloperEdge {
 type InstitutionOperatedDatabaseConnection {
   canCurrentUserAddEdge: Boolean!
   edges: [InstitutionOperatedDatabaseEdge!]!
+  pageInfo: PageInfo!
 }
 
 type InstitutionOperatedDatabaseEdge {
@@ -620,6 +795,7 @@ type InstitutionOperatedDatabaseEdge {
 type InstitutionRepresentativeConnection {
   canCurrentUserAddEdge: Boolean!
   edges: [InstitutionRepresentativeEdge!]!
+  pageInfo: PageInfo!
 }
 
 type InstitutionRepresentativeEdge {
@@ -699,6 +875,7 @@ type MethodConnection {
 
 type MethodDeveloperConnection {
   edges: [MethodDeveloperEdge!]!
+  pageInfo: PageInfo!
 }
 
 type MethodDeveloperEdge {
@@ -718,46 +895,107 @@ type MethodManagerEdge {
 }
 
 type Mutation {
-  addInstitutionRepresentative(input: AddInstitutionRepresentativeInput!): AddInstitutionRepresentativePayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  addInstitutionRepresentative(
+    input: AddInstitutionRepresentativeInput!
+  ): AddInstitutionRepresentativePayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
   addUserRole(input: AddUserRoleInput!): AddUserRolePayload!
-  changeInstitutionRepresentativeRole(input: ChangeInstitutionRepresentativeRoleInput!): ChangeInstitutionRepresentativeRolePayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  changeUserEmail(input: ChangeUserEmailInput!): ChangeUserEmailPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  changeUserPassword(input: ChangeUserPasswordInput!): ChangeUserPasswordPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  confirmComponentManufacturer(input: ConfirmComponentManufacturerInput!): ConfirmComponentManufacturerPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  confirmInstitutionMethodDeveloper(input: ConfirmInstitutionMethodDeveloperInput!): ConfirmInstitutionMethodDeveloperPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  confirmInstitutionRepresentative(input: ConfirmInstitutionRepresentativeInput!): ConfirmInstitutionRepresentativePayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  changeInstitutionRepresentativeRole(
+    input: ChangeInstitutionRepresentativeRoleInput!
+  ): ChangeInstitutionRepresentativeRolePayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  changeUserEmail(input: ChangeUserEmailInput!): ChangeUserEmailPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  changeUserPassword(
+    input: ChangeUserPasswordInput!
+  ): ChangeUserPasswordPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  confirmComponentManufacturer(
+    input: ConfirmComponentManufacturerInput!
+  ): ConfirmComponentManufacturerPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  confirmInstitutionMethodDeveloper(
+    input: ConfirmInstitutionMethodDeveloperInput!
+  ): ConfirmInstitutionMethodDeveloperPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  confirmInstitutionRepresentative(
+    input: ConfirmInstitutionRepresentativeInput!
+  ): ConfirmInstitutionRepresentativePayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
   confirmUserEmail(input: ConfirmUserEmailInput!): ConfirmUserEmailPayload!
-  confirmUserEmailChange(input: ConfirmUserEmailChangeInput!): ConfirmUserEmailChangePayload!
-  confirmUserMethodDeveloper(input: ConfirmUserMethodDeveloperInput!): ConfirmUserMethodDeveloperPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  createComponent(input: CreateComponentInput!): CreateComponentPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  createDatabase(input: CreateDatabaseInput!): CreateDatabasePayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  createDataFormat(input: CreateDataFormatInput!): CreateDataFormatPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  createInstitution(input: CreateInstitutionInput!): CreateInstitutionPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  createMethod(input: CreateMethodInput!): CreateMethodPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  deleteInstitution(input: DeleteInstitutionInput!): DeleteInstitutionPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  deletePersonalUserData(input: DeletePersonalUserDataInput!): DeletePersonalUserDataPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  deleteUser(input: DeleteUserInput!): DeleteUserPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  disableUserTwoFactorAuthentication: DisableUserTwoFactorAuthenticationPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  enableUserTwoFactorAuthenticator(input: EnableUserTwoFactorAuthenticatorInput!): EnableUserTwoFactorAuthenticatorPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  forgetUserTwoFactorAuthenticationClient: ForgetUserTwoFactorAuthenticationClientPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  generateUserTwoFactorAuthenticatorSharedKeyAndQrCodeUri: GenerateUserTwoFactorAuthenticatorSharedKeyAndQrCodeUriPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  generateUserTwoFactorRecoveryCodes: GenerateUserTwoFactorRecoveryCodesPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  confirmUserEmailChange(
+    input: ConfirmUserEmailChangeInput!
+  ): ConfirmUserEmailChangePayload!
+  confirmUserMethodDeveloper(
+    input: ConfirmUserMethodDeveloperInput!
+  ): ConfirmUserMethodDeveloperPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  createComponent(input: CreateComponentInput!): CreateComponentPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  createDatabase(input: CreateDatabaseInput!): CreateDatabasePayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  createDataFormat(input: CreateDataFormatInput!): CreateDataFormatPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  createInstitution(input: CreateInstitutionInput!): CreateInstitutionPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  createMethod(input: CreateMethodInput!): CreateMethodPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  deleteInstitution(input: DeleteInstitutionInput!): DeleteInstitutionPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  deletePersonalUserData(
+    input: DeletePersonalUserDataInput!
+  ): DeletePersonalUserDataPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  deleteUser(input: DeleteUserInput!): DeleteUserPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  disableUserTwoFactorAuthentication: DisableUserTwoFactorAuthenticationPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  enableUserTwoFactorAuthenticator(
+    input: EnableUserTwoFactorAuthenticatorInput!
+  ): EnableUserTwoFactorAuthenticatorPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  forgetUserTwoFactorAuthenticationClient: ForgetUserTwoFactorAuthenticationClientPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  generateUserTwoFactorAuthenticatorSharedKeyAndQrCodeUri: GenerateUserTwoFactorAuthenticatorSharedKeyAndQrCodeUriPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  generateUserTwoFactorRecoveryCodes: GenerateUserTwoFactorRecoveryCodesPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
   loginUser(input: LoginUserInput!): LoginUserPayload!
-  loginUserWithRecoveryCode(input: LoginUserWithRecoveryCodeInput!): LoginUserWithRecoveryCodePayload!
-  loginUserWithTwoFactorCode(input: LoginUserWithTwoFactorCodeInput!): LoginUserWithTwoFactorCodePayload!
-  logoutUser: LogoutUserPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  loginUserWithRecoveryCode(
+    input: LoginUserWithRecoveryCodeInput!
+  ): LoginUserWithRecoveryCodePayload!
+  loginUserWithTwoFactorCode(
+    input: LoginUserWithTwoFactorCodeInput!
+  ): LoginUserWithTwoFactorCodePayload!
+  logoutUser: LogoutUserPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
   registerUser(input: RegisterUserInput!): RegisterUserPayload!
-  removeInstitutionRepresentative(input: RemoveInstitutionRepresentativeInput!): RemoveInstitutionRepresentativePayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  removeInstitutionRepresentative(
+    input: RemoveInstitutionRepresentativeInput!
+  ): RemoveInstitutionRepresentativePayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
   removeUserRole(input: RemoveUserRoleInput!): RemoveUserRolePayload!
-  requestUserPasswordReset(input: RequestUserPasswordResetInput!): RequestUserPasswordResetPayload!
-  resendUserEmailConfirmation(input: ResendUserEmailConfirmationInput!): ResendUserEmailConfirmationPayload!
-  resendUserEmailVerification: ResendUserEmailVerificationPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  requestUserPasswordReset(
+    input: RequestUserPasswordResetInput!
+  ): RequestUserPasswordResetPayload!
+  resendUserEmailConfirmation(
+    input: ResendUserEmailConfirmationInput!
+  ): ResendUserEmailConfirmationPayload!
+  resendUserEmailVerification: ResendUserEmailVerificationPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
   resetUserPassword(input: ResetUserPasswordInput!): ResetUserPasswordPayload!
-  resetUserTwoFactorAuthenticator: ResetUserTwoFactorAuthenticatorPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  setUserPassword(input: SetUserPasswordInput!): SetUserPasswordPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  setUserPhoneNumber(input: SetUserPhoneNumberInput!): SetUserPhoneNumberPayload! @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
-  updateInstitution(input: UpdateInstitutionInput!): UpdateInstitutionPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
-  verifyInstitution(input: VerifyInstitutionInput!): VerifyInstitutionPayload! @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  resetUserTwoFactorAuthenticator: ResetUserTwoFactorAuthenticatorPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  setUserPassword(input: SetUserPasswordInput!): SetUserPasswordPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  setUserPhoneNumber(
+    input: SetUserPhoneNumberInput!
+  ): SetUserPhoneNumberPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "ManageUser")
+  updateInstitution(input: UpdateInstitutionInput!): UpdateInstitutionPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
+  verifyInstitution(input: VerifyInstitutionInput!): VerifyInstitutionPayload!
+    @authorize(apply: BEFORE_RESOLVER, policy: "Write")
 }
 
 type NamedMethodArgument {
@@ -848,6 +1086,7 @@ type OpticalData implements Data {
 type OpticalDataConnection {
   edges: [OpticalDataEdge!]!
   nodes: [OpticalData!]!
+  pageInfo: PageInfo!
   timestamp: DateTime!
   totalCount: NonNegativeInt
 }
@@ -882,6 +1121,7 @@ type PhotovoltaicData implements Data {
 type PhotovoltaicDataConnection {
   edges: [PhotovoltaicDataEdge!]!
   nodes: [PhotovoltaicData!]!
+  pageInfo: PageInfo!
   timestamp: DateTime!
   totalCount: NonNegativeInt
 }
@@ -893,7 +1133,7 @@ type PhotovoltaicDataEdge {
 
 type Publication implements Reference {
   abstract: String
-  "arXiv.org is a free and open-access archive for publications. The arXiv identifier can be used to define a publication."
+  "A free and open-access archive for publications is offered by arXiv.org. The arXiv identifier can be used to define a publication."
   arXiv: String
   authors: [String!]
   "The Digital Object Identifier (DOI) is a very important persistent identifier for publications. It MUST be defined here if it is available for a publication."
@@ -909,23 +1149,64 @@ type Publication implements Reference {
 
 type Query {
   component(uuid: Uuid!): Component
-  components(after: String before: String first: Int last: Int order: [ComponentSortInput!] where: ComponentFilterInput): ComponentConnection
+  components(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    order: [ComponentSortInput!]
+    where: ComponentFilterInput
+  ): ComponentConnection
   currentUser: User
   database(uuid: Uuid!): Database
-  databases(after: String before: String first: Int last: Int order: [DatabaseSortInput!] where: DatabaseFilterInput): DatabaseConnection
+  databases(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    order: [DatabaseSortInput!]
+    where: DatabaseFilterInput
+  ): DatabaseConnection
   dataFormat(uuid: Uuid!): DataFormat
-  dataFormats(after: String before: String first: Int last: Int order: [DataFormatSortInput!] where: DataFormatFilterInput): DataFormatConnection
+  dataFormats(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    order: [DataFormatSortInput!]
+    where: DataFormatFilterInput
+  ): DataFormatConnection
   institution(uuid: Uuid!): Institution
-  institutions(after: String before: String first: Int last: Int order: [InstitutionSortInput!] where: InstitutionFilterInput): InstitutionConnection
+  institutions(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    order: [InstitutionSortInput!]
+    where: InstitutionFilterInput
+  ): InstitutionConnection
   method(uuid: Uuid!): Method
-  methods(after: String before: String first: Int last: Int order: [MethodSortInput!] where: MethodFilterInput): MethodConnection
+  methods(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    order: [MethodSortInput!]
+    where: MethodFilterInput
+  ): MethodConnection
   node(id: ID!): Node
   openIdConnectApplications: [OpenIdConnectApplication!]!
   openIdConnectAuthorizations: [OpenIdConnectAuthorization!]!
   openIdConnectScopes: [OpenIdConnectScope!]!
   openIdConnectTokens: [OpenIdConnectToken!]!
   user(uuid: Uuid!): User
-  users(after: String before: String first: Int last: Int order: [UserSortInput!]): UserConnection
+  users(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    order: [UserSortInput!]
+  ): UserConnection
 }
 
 type RegisterUserError {
@@ -1092,7 +1373,9 @@ type User implements Node & Stakeholder {
   "Full name"
   name: String!
   phoneNumber: String
-  representedInstitutions(pending: Boolean! = false): UserRepresentedInstitutionConnection!
+  representedInstitutions(
+    pending: Boolean! = false
+  ): UserRepresentedInstitutionConnection!
   roles: [UserRole!]
   rolesCurrentUserCanAdd: [UserRole!]
   rolesCurrentUserCanRemove: [UserRole!]
@@ -1115,6 +1398,7 @@ type UserConnection {
 type UserDevelopedMethodConnection {
   canCurrentUserConfirmEdge: Boolean!
   edges: [UserDevelopedMethodEdge!]!
+  pageInfo: PageInfo!
 }
 
 type UserDevelopedMethodEdge {
@@ -1136,6 +1420,7 @@ type UserMethodDeveloperEdge {
 type UserRepresentedInstitutionConnection {
   canCurrentUserConfirmEdge: Boolean!
   edges: [UserRepresentedInstitutionEdge!]!
+  pageInfo: PageInfo!
 }
 
 type UserRepresentedInstitutionEdge {
@@ -1581,7 +1866,7 @@ input PhotovoltaicDataPropositionInput {
 
 input PublicationSortInput {
   abstract: SortEnumType
-  "arXiv.org is a free and open-access archive for publications. The arXiv identifier can be used to define a publication."
+  "A free and open-access archive for publications is offered by arXiv.org. The arXiv identifier can be used to define a publication."
   arXiv: SortEnumType
   "The Digital Object Identifier (DOI) is a very important persistent identifier for publications. It MUST be defined here if it is available for a publication."
   doi: SortEnumType
@@ -2117,19 +2402,41 @@ enum VerifyInstitutionErrorCode {
   UNAUTHORIZED
 }
 
-directive @authorize("Defines when when the resolver shall be executed.By default the resolver is executed after the policy has determined that the current user is allowed to access the field." apply: ApplyPolicy! = BEFORE_RESOLVER "The name of the authorization policy that determines access to the annotated resource." policy: String "Roles that are allowed to access the annotated resource." roles: [String!]) repeatable on SCHEMA | OBJECT | FIELD_DEFINITION
+directive @authorize(
+  "Defines when when the resolver shall be executed.By default the resolver is executed after the policy has determined that the current user is allowed to access the field."
+  apply: ApplyPolicy! = BEFORE_RESOLVER
+  "The name of the authorization policy that determines access to the annotated resource."
+  policy: String
+  "Roles that are allowed to access the annotated resource."
+  roles: [String!]
+) repeatable on SCHEMA | OBJECT | FIELD_DEFINITION
 
 "The `@defer` directive may be provided for fragment spreads and inline fragments to inform the executor to delay the execution of the current fragment to indicate deprioritization of the current fragment. A query with `@defer` directive will cause the request to potentially return multiple responses, where non-deferred data is delivered in the initial response and data deferred is delivered in a subsequent response. `@include` and `@skip` take precedence over `@defer`."
-directive @defer("Deferred when true." if: Boolean "If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to." label: String) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @defer(
+  "Deferred when true."
+  if: Boolean
+  "If this argument label has a value other than null, it will be passed on to the result of this defer directive. This label is intended to give client applications a way to identify to which fragment a deferred result belongs to."
+  label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 "The `@specifiedBy` directive is used within the type system definition language to provide a URL for specifying the behavior of custom scalar definitions."
-directive @specifiedBy("The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types." url: String!) on SCALAR
+directive @specifiedBy(
+  "The specifiedBy URL points to a human-readable specification. This field will only read a result for scalar types."
+  url: String!
+) on SCALAR
 
 "The `@stream` directive may be provided for a field of `List` type so that the backend can leverage technology such as asynchronous iterators to provide a partial list in the initial response, and additional list items in subsequent responses. `@include` and `@skip` take precedence over `@stream`."
-directive @stream("Streamed when true." if: Boolean! "The initial elements that shall be send down to the consumer." initialCount: Int! "If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to." label: String) on FIELD
+directive @stream(
+  "Streamed when true."
+  if: Boolean!
+  "The initial elements that shall be send down to the consumer."
+  initialCount: Int!
+  "If this argument label has a value other than null, it will be passed on to the result of this stream directive. This label is intended to give client applications a way to identify to which fragment a streamed result belongs to."
+  label: String
+) on FIELD
 
 "The `DateTime` scalar represents an ISO-8601 compliant date time type."
-scalar DateTime @specifiedBy(url: "https:\/\/www.graphql-scalars.com\/date-time")
+scalar DateTime @specifiedBy(url: "https://www.graphql-scalars.com/date-time")
 
 "The NonNegativeInt scalar type represents a unsigned 32-bit numeric non-fractional value equal to or greater than 0."
 scalar NonNegativeInt

--- a/examples/dbe/assembly/collectorFieldAsGeometricAssembly.json
+++ b/examples/dbe/assembly/collectorFieldAsGeometricAssembly.json
@@ -5,23 +5,53 @@
       "description": "This example represents the solar thermal collectors of a building.",
       "characteristics": {
         "geometry": {
+          "origin": {
+            "latitude": 48.00883171395494,
+            "longitude": 7.834452327404689,
+            "elevation": 278
+          },
+          "definitionOfSurfacesAndPrimeDirections": {
+            "description": "On each collector, the product number is at the bottom right corner facing the interior. The direction from the bottom to the top in parallel to the largest dimension of the collector is the prime direction. The collector surface facing the exterior is the non-prime surface."
+          },
           "assemblyList": [
             {
               "id": "cd85554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": {
-                    "smallest": 0.004
-                  }
+              "dimensions": {
+                "independent": {
+                  "smallest": 0.1,
+                  "intermediate": 0.9,
+                  "largest": 1.4
                 }
+              },
+              "location": {
+                "south": 0,
+                "east": 5,
+                "elevation": 5
+              },
+              "orientation": {
+                "azimuth": 180,
+                "tilt": 90,
+                "rotation": 0
               }
             },
             {
               "id": "cd95554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": { "smallest": 0.001 }
+              "dimensions": {
+                "independent": {
+                  "smallest": 0.1,
+                  "intermediate": 0.9,
+                  "largest": 1.4
                 }
+              },
+              "location": {
+                "south": -5,
+                "east": 0,
+                "elevation": 5
+              },
+              "orientation": {
+                "azimuth": 270,
+                "tilt": 90,
+                "rotation": 0
               }
             }
           ]

--- a/examples/dbe/assembly/collectorFieldAsGeometricAssembly.json
+++ b/examples/dbe/assembly/collectorFieldAsGeometricAssembly.json
@@ -1,0 +1,32 @@
+{
+  "components": [
+    {
+      "id": "cd7aed0a-2b9a-4748-8d98-e9d278cd12e4",
+      "description": "This example represents the solar thermal collectors of a building.",
+      "characteristics": {
+        "geometry": {
+          "assemblyList": [
+            {
+              "id": "cd85554f-e909-405e-9b7b-2f08ca201f63",
+              "geometry": {
+                "dimensions": {
+                  "independent": {
+                    "smallest": 0.004
+                  }
+                }
+              }
+            },
+            {
+              "id": "cd95554f-e909-405e-9b7b-2f08ca201f63",
+              "geometry": {
+                "dimensions": {
+                  "independent": { "smallest": 0.001 }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json
+++ b/examples/dbe/photovoltaic/bipvModuleBuildingNatIse.json
@@ -11,54 +11,46 @@
           "assemblyList": [
             {
               "id": "01f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": {
-                    "smallest": 0.0038,
-                    "intermediate": {
-                      "uncertainValue": 1.08,
-                      "uncertainty": 0.01,
-                      "confidenceInterval": 68.3
-                    },
-                    "largest": {
-                      "uncertainValue": 1.09,
-                      "uncertainty": 0.01,
-                      "confidenceInterval": 68.3
-                    }
+              "dimensions": {
+                "independent": {
+                  "smallest": 0.0038,
+                  "intermediate": {
+                    "uncertainValue": 1.08,
+                    "uncertainty": 0.01,
+                    "confidenceInterval": 68.3
+                  },
+                  "largest": {
+                    "uncertainValue": 1.09,
+                    "uncertainty": 0.01,
+                    "confidenceInterval": 68.3
                   }
                 }
               }
             },
             {
               "id": "02f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": { "smallest": 0.002 }
-                }
+              "dimensions": {
+                "independent": { "smallest": 0.002 }
               }
             },
             {
               "id": "03f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": { "smallest": 0.0004 }
-                }
+
+              "dimensions": {
+                "independent": { "smallest": 0.0004 }
               }
             },
             {
               "id": "04f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": { "smallest": 0.002 }
-                }
+              "dimensions": {
+                "independent": { "smallest": 0.002 }
               }
             },
             {
               "id": "05f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": { "smallest": 0.002 }
-                }
+
+              "dimensions": {
+                "independent": { "smallest": 0.002 }
               }
             }
           ]

--- a/examples/dbe/photovoltaic/bipvModuleSunovationLayer.json
+++ b/examples/dbe/photovoltaic/bipvModuleSunovationLayer.json
@@ -13,28 +13,25 @@
           "assemblyList": [
             {
               "id": "01f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": {
-                    "smallest": 0.004
-                  }
+
+              "dimensions": {
+                "independent": {
+                  "smallest": 0.004
                 }
               }
             },
             {
               "id": "02f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": { "smallest": 0.001 }
-                }
+
+              "dimensions": {
+                "independent": { "smallest": 0.001 }
               }
             },
             {
               "id": "03f5554f-e909-405e-9b7b-2f08ca201f63",
-              "geometry": {
-                "dimensions": {
-                  "independent": { "smallest": 0.008 }
-                }
+
+              "dimensions": {
+                "independent": { "smallest": 0.008 }
               }
             }
           ]

--- a/schemas/building.json
+++ b/schemas/building.json
@@ -290,15 +290,15 @@
           "properties": {
             "latitude": {
               "$ref": "number.json#/$defs/latitude",
-              "description": "The latitude of the location of the building as a decimal number according to WGS 84."
+              "description": "The latitude of the location of the building."
             },
             "longitude": {
               "$ref": "number.json#/$defs/longitude",
-              "description": "The longitude of the location of the building as a decimal number according to WGS 84."
+              "description": "The longitude of the location of the building."
             },
             "elevation": {
-              "$ref": "number.json#/$defs/meter",
-              "description": "The elevation of the location of the building. It has the SI unit meter."
+              "$ref": "number.json#/$defs/elevation",
+              "description": "The elevation of the location of the building. "
             },
             "address": {
               "$ref": "#/$defs/address",

--- a/schemas/component.json
+++ b/schemas/component.json
@@ -391,7 +391,7 @@
         },
         "definitionOfSurfacesAndPrimeDirection": {
           "title": "Definition of surfaces and prime direction",
-          "description": "The prime direction must be equal to the direction of the profile angle symmetry.",
+          "description": "The prime surface and the prime direction are used to define the orientation of the component. If there is a `profileAngle` symmetry, the prime direction must be equal to the direction of the profile angle symmetry.",
           "type": "object",
           "properties": {
             "reference": {
@@ -402,7 +402,7 @@
             "description": {
               "type": "string",
               "title": "Description",
-              "description": "Description of which side of the component is defined as non-prime and which as prime, and which side is top and which side is bottom. Often, the non-prime side faces the exterior and the prime side the interior."
+              "description": "Description of which sides of the components are defined as non-prime and which as prime and which direction is defined as the prime direction. Often, the non-prime side faces the exterior and the prime side the interior."
             }
           },
           "minProperties": 1,

--- a/schemas/component.json
+++ b/schemas/component.json
@@ -234,7 +234,7 @@
               "$ref": "geometry.json"
             },
             {
-              "$ref": "#/$defs/assembly"
+              "$ref": "geometry.json#/$defs/assembly"
             }
           ]
         },
@@ -463,66 +463,6 @@
       "additionalProperties": false,
       "minProperties": 1,
       "required": []
-    },
-    "assembly": {
-      "title": "An assembly of components where each item of the array defines one component of the assembly. Note that one component can either consist of a single component or of an assembly of components.",
-      "type": "object",
-      "properties": {
-        "coordinateSystemAssembly": {
-          "$ref": "geometry.json#/$defs/coordinateSystem",
-          "description": "Definition of the coordinate system of the assembly."
-        },
-        "assemblyList": {
-          "title": "The subcomponents which are used for this assembly.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "$ref": "identifier.json#/$defs/centralOrDecentral",
-                "description": "The id represents a specific component of the assembly."
-              },
-              "geometry": {
-                "$ref": "geometry.json",
-                "description": "The reference defines the geometry of the component."
-              },
-              "coordinateSystemComponent": {
-                "title": "Coordinates of the origin and axis of the component within the coordinate system of the assembly. Often, it is easier to define this relation than to convert all geometries into the coordinate system of the assembly. Note that the assembly has a coordinate system and each component has its own coordinate system.",
-                "type": "object",
-                "properties": {
-                  "origin": {
-                    "$ref": "geometry.json#/$defs/point",
-                    "description": "This point defines the coordinates of the origin of the component within the coordinate system of the assembly."
-                  },
-                  "firstAxis": {
-                    "$ref": "geometry.json#/$defs/vector",
-                    "description": "The coordinate system of the component has three axis. This vector defines the direction of the first axis within the coordinate system of the assembly."
-                  },
-                  "secondAxis": {
-                    "$ref": "geometry.json#/$defs/vector",
-                    "description": "The coordinate system of the component has three axis. This vector defines the direction of the second axis within the coordinate system of the assembly."
-                  },
-                  "thirdAxis": {
-                    "$ref": "geometry.json#/$defs/vector",
-                    "description": "The coordinate system of the component has three axis. This vector defines the direction of the third axis within the coordinate system of the assembly."
-                  }
-                },
-                "additionalProperties": false,
-                "minProperties": 4,
-                "maxProperties": 4,
-                "required": ["origin", "firstAxis", "secondAxis", "thirdAxis"]
-              }
-            },
-            "additionalProperties": false,
-            "minProperties": 1,
-            "required": ["id"]
-          },
-          "minItems": 2
-        }
-      },
-      "additionalProperties": false,
-      "minProperties": 1,
-      "required": ["assemblyList"]
     },
     "surface": {
       "type": "string",

--- a/schemas/geometry.json
+++ b/schemas/geometry.json
@@ -64,9 +64,9 @@
           "$ref": "number.json#/$defs/meter",
           "description": "This distance is measured horizontally in the direction from the `origin` to the south. It has the SI unit of meter."
         },
-        "west": {
+        "east": {
           "$ref": "number.json#/$defs/meter",
-          "description": "This distance is measured horizontally in the direction from the `origin` to the west. It has the SI unit of meter."
+          "description": "This distance is measured horizontally in the direction from the `origin` to the east. It has the SI unit of meter."
         },
         "elevation": {
           "$ref": "number.json#/$defs/meter",
@@ -74,7 +74,7 @@
         }
       },
       "additionalProperties": false,
-      "required": ["south", "west"]
+      "required": ["south", "east"]
     },
     "orientation": {
       "title": "The orientation of the prime surface of the component.",
@@ -82,11 +82,15 @@
       "properties": {
         "azimuth": {
           "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixtyWithUncertainty",
-          "description": "When the normal of the prime surface is projected on a horizontal plane, then the azimuth angle of the component is the angle between this projection and the north direction. If the prime surface faces west, then the azimuth angle equals 90°."
+          "description": "When the normal of the non-prime surface is projected on a horizontal plane, then the azimuth angle of the component is the angle between this projection and the north direction. If the prime surface faces west, then the azimuth angle equals 90°."
         },
         "tilt": {
           "$ref": "number.json#/$defs/degreeBetweenZeroAndOneHundredEightyWithUncertainty",
-          "description": "The tilt angle of the component is the angle between the prime surface and a horizontal plane. If the prime surface is horizontal and faces the sky, then the tilt angle equals 0°. If the prime surface is vertical, then the tilt angle equals 90°."
+          "description": "The tilt angle of the component is the angle between the non-prime surface and a horizontal plane. If the prime surface is horizontal and faces the sky, then the tilt angle equals 0°. If the prime surface is vertical, then the tilt angle equals 90°."
+        },
+        "rotation": {
+          "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixtyWithUncertainty",
+          "description": "The angle of rotation around the normal of the non-prime surface. First, imagine a plane which is rectangular to the non-prime surface and parallel to the direction of the azimuth angle. The cross-section from the bottom to the top is the first important direction. The rotation angle is the angle between this direction and the prime direction. If the prime direction leads from the bottom to the top, then the rotation angle equals 0°. If the prime direction leads from the left-hand side to the right-hand side as seen from the exterior, then the rotation angle equals 90°."
         }
       },
       "additionalProperties": false,
@@ -122,6 +126,25 @@
         "origin": {
           "$ref": "#/$defs/origin",
           "description": "The origin of the coordinate system which is used by `assemblyList/location`."
+        },
+        "definitionOfSurfacesAndPrimeDirections": {
+          "title": "Definition of surfaces and prime directions",
+          "description": "The prime surface and the prime direction are used to define the `orientation` of the component. If there is a `profileAngle` symmetry, the prime direction must be equal to the direction of the profile angle symmetry.",
+          "type": "object",
+          "properties": {
+            "reference": {
+              "$ref": "common.json#/$defs/reference",
+              "title": "Reference",
+              "description": "Reference that defines which surfaces of the components are defined as non-prime and which as prime. Often, the non-prime surface faces the exterior and the prime surface faces the interior. The reference should also define the prime directions of the components."
+            },
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "description": "Description of which sides of the components are defined as non-prime and which as prime and which direction is defined as the prime direction. Often, the non-prime side faces the exterior and the prime side the interior."
+            }
+          },
+          "minProperties": 1,
+          "required": []
         },
         "assemblyList": {
           "title": "The subcomponents which are used for this assembly.",

--- a/schemas/geometry.json
+++ b/schemas/geometry.json
@@ -13,91 +13,157 @@
           "description": "Height, width and depth of the component."
         },
         "origin": {
-          "title": "The origin of the coordinate system which is used by `location`.",
-          "type": "object",
-          "properties": {
-            "latitude": {
-              "$ref": "number.json#/$defs/latitude",
-              "description": "The latitude of the location of the building."
-            },
-            "longitude": {
-              "$ref": "number.json#/$defs/longitude",
-              "description": "The longitude of the location of the building."
-            },
-            "elevation": {
-              "$ref": "number.json#/$defs/elevation",
-              "description": "The elevation of the location of the building. "
-            }
-          },
-          "additionalProperties": false,
-          "required": ["latitude", "longitude"]
+          "$ref": "#/$defs/origin",
+          "description": "The origin of the coordinate system which is used by `location`."
         },
         "location": {
-          "title": "The location of the center of mass of the component.",
-          "type": "object",
-          "properties": {
-            "south": {
-              "$ref": "number.json#/$defs/meter",
-              "description": "This distance is measured horizontally in the direction from the `origin` to the south. It has the SI unit of meter."
-            },
-            "west": {
-              "$ref": "number.json#/$defs/meter",
-              "description": "This distance is measured horizontally in the direction from the `origin` to the west. It has the SI unit of meter."
-            },
-            "elevation": {
-              "$ref": "number.json#/$defs/meter",
-              "description": "This distance is measured vertically in the direction from the `origin` to the sky. It has the SI unit of meter."
-            }
-          },
-          "additionalProperties": false,
-          "required": ["south", "west"]
+          "$ref": "#/$defs/location",
+          "description": "The location of the center of mass of the component."
         },
         "orientation": {
-          "title": "The orientation of the prime surface of the component.",
-          "type": "object",
-          "properties": {
-            "azimuth": {
-              "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixtyWithUncertainty",
-              "description": "When the normal of the prime surface is projected on a horizontal plane, then the azimuth angle of the component is the angle between this projection and the north direction. If the prime surface faces west, then the azimuth angle equals 90°."
-            },
-            "tilt": {
-              "$ref": "number.json#/$defs/degreeBetweenZeroAndOneHundredEightyWithUncertainty",
-              "description": "The tilt angle of the component is the angle between the prime surface and a horizontal plane. If the prime surface is horizontal and faces the sky, then the tilt angle equals 0°. If the prime surface is vertical, then the tilt angle equals 90°."
-            }
-          },
-          "additionalProperties": false,
-          "required": ["azimuth", "tilt"]
+          "$ref": "#/$defs/orientation",
+          "description": "The orientation of the prime surface of the component."
         },
         "getHttpsResource": {
           "$ref": "common.json#/$defs/getHttpsResource",
           "description": "Instead of or in addition to the keys above, a file can be used to define the geometry of the component."
         },
-        "LOD": {
-          "title": "The Level of Development or Level of Detail (LOD) is used to describe how accurate the reality is modelled. As geometry/LOD refers to geometry, it is sometimes also called Level of Geometry.",
-          "type": "array",
-          "items": [
-            {
-              "$ref": "number.json#/$defs/nonNegativeInteger",
-              "description": "This integer indicates the LOD according to the definition of the reference below."
-            },
-            {
-              "type": "object",
-              "properties": {
-                "reference": {
-                  "$ref": "common.json#/$defs/reference",
-                  "description": "This reference defines the LOD which is indicated above."
-                }
-              },
-              "additionalProperties": false,
-              "required": ["reference"]
-            }
-          ],
-          "minItems": 2,
-          "additionalItems": false
+        "levelOfDevelopment": {
+          "$ref": "#/$defs/orientation",
+          "description": "The Level of Development or Level of Detail (LOD) is used to describe how accurate the reality is modelled."
         }
       },
       "additionalProperties": false,
       "required": []
+    },
+    "origin": {
+      "title": "The origin of the coordinate system which is used by `location`.",
+      "type": "object",
+      "properties": {
+        "latitude": {
+          "$ref": "number.json#/$defs/latitude",
+          "description": "The latitude of the location of the building."
+        },
+        "longitude": {
+          "$ref": "number.json#/$defs/longitude",
+          "description": "The longitude of the location of the building."
+        },
+        "elevation": {
+          "$ref": "number.json#/$defs/elevation",
+          "description": "The elevation of the location of the building. "
+        }
+      },
+      "additionalProperties": false,
+      "required": ["latitude", "longitude"]
+    },
+    "location": {
+      "title": "The location of the center of mass of the component.",
+      "type": "object",
+      "properties": {
+        "south": {
+          "$ref": "number.json#/$defs/meter",
+          "description": "This distance is measured horizontally in the direction from the `origin` to the south. It has the SI unit of meter."
+        },
+        "west": {
+          "$ref": "number.json#/$defs/meter",
+          "description": "This distance is measured horizontally in the direction from the `origin` to the west. It has the SI unit of meter."
+        },
+        "elevation": {
+          "$ref": "number.json#/$defs/meter",
+          "description": "This distance is measured vertically in the direction from the `origin` to the sky. It has the SI unit of meter."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["south", "west"]
+    },
+    "orientation": {
+      "title": "The orientation of the prime surface of the component.",
+      "type": "object",
+      "properties": {
+        "azimuth": {
+          "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixtyWithUncertainty",
+          "description": "When the normal of the prime surface is projected on a horizontal plane, then the azimuth angle of the component is the angle between this projection and the north direction. If the prime surface faces west, then the azimuth angle equals 90°."
+        },
+        "tilt": {
+          "$ref": "number.json#/$defs/degreeBetweenZeroAndOneHundredEightyWithUncertainty",
+          "description": "The tilt angle of the component is the angle between the prime surface and a horizontal plane. If the prime surface is horizontal and faces the sky, then the tilt angle equals 0°. If the prime surface is vertical, then the tilt angle equals 90°."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["azimuth", "tilt"]
+    },
+    "levelOfDevelopment": {
+      "title": "The Level of Development or Level of Detail (LOD) is used to describe how accurate the reality is modelled. As geometry/LOD refers to geometry, it is sometimes also called Level of Geometry.",
+      "type": "array",
+      "items": [
+        {
+          "$ref": "number.json#/$defs/nonNegativeInteger",
+          "description": "This integer indicates the LOD according to the definition of the reference below."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "reference": {
+              "$ref": "common.json#/$defs/reference",
+              "description": "This reference defines the LOD which is indicated above."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["reference"]
+        }
+      ],
+      "minItems": 2,
+      "additionalItems": false
+    },
+    "assembly": {
+      "title": "An assembly of components where each item of the array defines one component of the assembly. Note that one component can either consist of a single component or of an assembly of components.",
+      "type": "object",
+      "properties": {
+        "origin": {
+          "$ref": "#/$defs/origin",
+          "description": "The origin of the coordinate system which is used by `assemblyList/location`."
+        },
+        "assemblyList": {
+          "title": "The subcomponents which are used for this assembly.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "$ref": "identifier.json#/$defs/centralOrDecentral",
+                "description": "The id represents a specific component of the assembly."
+              },
+              "dimensions": {
+                "$ref": "#/$defs/dimensions",
+                "description": "Height, width and depth of the component."
+              },
+              "location": {
+                "$ref": "#/$defs/location",
+                "description": "The location of the center of mass of the component."
+              },
+              "orientation": {
+                "$ref": "#/$defs/orientation",
+                "description": "The orientation of the prime surface of the component."
+              },
+              "getHttpsResource": {
+                "$ref": "common.json#/$defs/getHttpsResource",
+                "description": "Instead of or in addition to the keys above, a file can be used to define the geometry of the component."
+              },
+              "levelOfDevelopment": {
+                "$ref": "#/$defs/orientation",
+                "description": "The Level of Development or Level of Detail (LOD) is used to describe how accurate the reality is modelled."
+              }
+            },
+            "additionalProperties": false,
+            "minProperties": 1,
+            "required": ["id"]
+          },
+          "minItems": 2
+        }
+      },
+      "additionalProperties": false,
+      "minProperties": 1,
+      "required": ["assemblyList"]
     },
     "point": {
       "title": "A point according to the definition of a coordinate system elsewhere.",

--- a/schemas/geometry.json
+++ b/schemas/geometry.json
@@ -58,11 +58,11 @@
           "properties": {
             "azimuth": {
               "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixtyWithUncertainty",
-              "description": "When the normal of the prime surface is projected on a horizontal plane, then the azimuth angle of the component is the angle between this projection and the north direction. If the prime surface faces west, the azimuth angle equals 90°."
+              "description": "When the normal of the prime surface is projected on a horizontal plane, then the azimuth angle of the component is the angle between this projection and the north direction. If the prime surface faces west, then the azimuth angle equals 90°."
             },
             "tilt": {
               "$ref": "number.json#/$defs/degreeBetweenZeroAndOneHundredEightyWithUncertainty",
-              "description": "The tilt angle of the component is the angle between the normal of the prime surface and a horizontal plane. If the prime surface is vertical, the tilt angle equals 90°."
+              "description": "The tilt angle of the component is the angle between the prime surface and a horizontal plane. If the prime surface is horizontal and faces the sky, then the tilt angle equals 0°. If the prime surface is vertical, then the tilt angle equals 90°."
             }
           },
           "additionalProperties": false,

--- a/schemas/geometry.json
+++ b/schemas/geometry.json
@@ -12,9 +12,61 @@
           "$ref": "#/$defs/dimensions",
           "description": "Height, width and depth of the component."
         },
-        "coordinateSystem": {
-          "$ref": "#/$defs/coordinateSystem",
-          "description": "Definition of the coordinate systems to which the other coordinates refer to."
+        "origin": {
+          "title": "The origin of the coordinate system which is used by `location`.",
+          "type": "object",
+          "properties": {
+            "latitude": {
+              "$ref": "number.json#/$defs/latitude",
+              "description": "The latitude of the location of the building."
+            },
+            "longitude": {
+              "$ref": "number.json#/$defs/longitude",
+              "description": "The longitude of the location of the building."
+            },
+            "elevation": {
+              "$ref": "number.json#/$defs/elevation",
+              "description": "The elevation of the location of the building. "
+            }
+          },
+          "additionalProperties": false,
+          "required": ["latitude", "longitude"]
+        },
+        "location": {
+          "title": "The location of the center of mass of the component.",
+          "type": "object",
+          "properties": {
+            "south": {
+              "$ref": "number.json#/$defs/meter",
+              "description": "This distance is measured horizontally in the direction from the `origin` to the south. It has the SI unit of meter."
+            },
+            "west": {
+              "$ref": "number.json#/$defs/meter",
+              "description": "This distance is measured horizontally in the direction from the `origin` to the west. It has the SI unit of meter."
+            },
+            "elevation": {
+              "$ref": "number.json#/$defs/meter",
+              "description": "This distance is measured vertically in the direction from the `origin` to the sky. It has the SI unit of meter."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["south", "west"]
+        },
+        "orientation": {
+          "title": "The orientation of the prime surface of the component.",
+          "type": "object",
+          "properties": {
+            "azimuth": {
+              "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixtyWithUncertainty",
+              "description": "When the normal of the prime surface is projected on a horizontal plane, then the azimuth angle of the component is the angle between this projection and the north direction. If the prime surface faces west, the azimuth angle equals 90°."
+            },
+            "tilt": {
+              "$ref": "number.json#/$defs/degreeBetweenZeroAndOneHundredEightyWithUncertainty",
+              "description": "The tilt angle of the component is the angle between the normal of the prime surface and a horizontal plane. If the prime surface is vertical, the tilt angle equals 90°."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["azimuth", "tilt"]
         },
         "getHttpsResource": {
           "$ref": "common.json#/$defs/getHttpsResource",

--- a/schemas/number.json
+++ b/schemas/number.json
@@ -141,20 +141,20 @@
       "minimum": 0,
       "maximum": 90
     },
+    "numberBetweenZeroAndOneHundredEighty": {
+      "description": "This type is used when only numbers between 0 and 90 are valid and no uncertainty can occur.",
+      "type": "number",
+      "minimum": 0,
+      "maximum": 180
+    },
     "numberBetweenZeroAndThreeHundredSixty": {
       "description": "This type is used when only numbers between 0 and 90 are valid and no uncertainty can occur.",
       "type": "number",
       "minimum": 0,
       "maximum": 360
     },
-    "latitude": {
-      "description": "Latitude geographic coordinate that specifies the north–south position of a point on the Earth's surface.",
-      "type": "number",
-      "minimum": -90,
-      "maximum": 90
-    },
-    "longitude": {
-      "description": "Longitude geographic coordinate that specifies the east-west position of a point on the Earth's surface.",
+    "numberBetweenMinusOneHundredEightyAndPlusOneHundredEighty": {
+      "description": "This type is used when only numbers between -180 and 180 are valid and no uncertainty can occur.",
       "type": "number",
       "minimum": -180,
       "maximum": 180
@@ -244,7 +244,32 @@
         }
       ]
     },
-    "degreeBetweenZeroAndThreeHundredSixty": {
+    "degreeBetweenZeroAndOneHundredEightyWithUncertainty": {
+      "title": "If a number can have values between 0° and 180° and may have an uncertainty, then this schema is used. If the uncertainty is unknown, only one number is defined. If the uncertainty is known, the mean value is defined as `uncertainValue`, the uncertainty as `uncertainty` and the confidence interval as `confidenceInterval`.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/numberBetweenZeroAndOneHundredEighty",
+          "description": "If the uncertainty is unknown, then this this option is used."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "uncertainValue": {
+              "$ref": "#/$defs/numberBetweenZeroAndOneHundredEighty"
+            },
+            "uncertainty": {
+              "$ref": "#/$defs/uncertaintyNumber"
+            },
+            "confidenceInterval": {
+              "$ref": "#/$defs/confidenceInterval"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["uncertainValue", "uncertainty", "confidenceInterval"]
+        }
+      ]
+    },
+    "degreeBetweenZeroAndThreeHundredSixtyWithUncertainty": {
       "title": "If a number can have values between 0° and 360° and may have an uncertainty, then this schema is used. If the uncertainty is unknown, only one number is defined. If the uncertainty is known, the mean value is defined as `uncertainValue`, the uncertainty as `uncertainty` and the confidence interval as `confidenceInterval`.",
       "oneOf": [
         {
@@ -256,6 +281,31 @@
           "properties": {
             "uncertainValue": {
               "$ref": "#/$defs/numberBetweenZeroAndThreeHundredSixty"
+            },
+            "uncertainty": {
+              "$ref": "#/$defs/uncertaintyNumber"
+            },
+            "confidenceInterval": {
+              "$ref": "#/$defs/confidenceInterval"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["uncertainValue", "uncertainty", "confidenceInterval"]
+        }
+      ]
+    },
+    "degreeBetweenMinusOneHundredEightyAndPlusOneHundredEightyWithUncertainty": {
+      "title": "If a number can have values between -180° and 180° and may have an uncertainty, then this schema is used. If the uncertainty is unknown, only one number is defined. If the uncertainty is known, the mean value is defined as `uncertainValue`, the uncertainty as `uncertainty` and the confidence interval as `confidenceInterval`.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/numberBetweenMinusOneHundredEightyAndPlusOneHundredEighty",
+          "description": "If the uncertainty is unknown, then this this option is used."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "uncertainValue": {
+              "$ref": "#/$defs/numberBetweenMinusOneHundredEightyAndPlusOneHundredEighty"
             },
             "uncertainty": {
               "$ref": "#/$defs/uncertaintyNumber"
@@ -372,6 +422,18 @@
       "type": "number",
       "minimum": 0,
       "maximum": 100
+    },
+    "latitude": {
+      "$ref": "#/$defs/degreeBetweenZeroAndNinetyWithUncertainty",
+      "description": "The angle between the equatorial plane and the straight line between the location and the center of the earth. North is positive. For example, Berlin has a latitude of 52.52 ."
+    },
+    "longitude": {
+      "$ref": "#/$defs/degreeBetweenMinusOneHundredEightyAndPlusOneHundredEightyWithUncertainty",
+      "description": "The angle between the Greenwich meridian and the straight line between the location and the center of the earth. West is positive. For example, Berlin has a longitude of 13.405 ."
+    },
+    "elevation": {
+      "$ref": "number.json#/$defs/meter",
+      "description": "The elevation above sea level. It has the SI unit meter."
     }
   }
 }

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -242,7 +242,7 @@
               "description": "The polar angle is the angle between the direction of incidence and an axis which is perpendicular to the surface of the sample. It can have values between 0° and 90°. A polar angle of 0° means that the direction of incidence is perpendicular to the sample. A polar angle of 90° means that the direction of incidence is parallel to the sample. If the sample has `azimuthalAngleInvariance`, then the optical results depend only on the polar angle and not on the azimuth angle. If the sample has a `profileAngle` symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
             },
             "azimuth": {
-              "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixty",
+              "$ref": "number.json#/$defs/degreeBetweenZeroAndThreeHundredSixtyWithUncertainty",
               "description": "The direction of incidence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. It can have values between 0° and 360°. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth equals 30° because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
             }
           },

--- a/schemas/opticalData.json
+++ b/schemas/opticalData.json
@@ -259,7 +259,7 @@
     },
     "emergenceDirection": {
       "title": "Emergence direction",
-      "description": "Direction of radiation emerging from a sample either by transmission or reflection.",
+      "description": "Direction of emergent radiation from a sample. An polar angle of 10° or less as defined in the technical report [CIE 130-1998, Practical methods for the measurement of reflectance and transmittance](http://cie.co.at/publications/practical-methods-measurement-reflectance-and-transmittance) is called 'nearnormal' and said to be 'almost perpendicular'.",
       "oneOf": [
         {
           "description": "Direction of emergence in a spherical coordinate system according to [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html).",
@@ -267,11 +267,11 @@
           "properties": {
             "polar": {
               "$ref": "number.json#/$defs/degreeWithUncertainty",
-              "description": "The polar angle is the angle between the direction of emergence and an axis which is perpendicular to the surface of the sample. A polar angle of 0° means that the direction of emergence is perpendicular to the sample."
+              "description": "The polar angle is the angle between the direction of emergence and an axis which is perpendicular to the surface of the sample. It can have values between 0° and 90°. A polar angle of 0° means that the direction of emergence is perpendicular to the sample. A polar angle of 90° means that the direction of emergence is parallel to the sample. If the sample has `azimuthalAngleInvariance`, then the optical results depend only on the polar angle and not on the azimuth angle. If the sample has a `profileAngle` symmetry whose direction is equal to the prime direction, then the profile angle can be calculated from the polar and azimuth angles."
             },
             "azimuth": {
               "$ref": "number.json#/$defs/degreeWithUncertainty",
-              "description": "The direction of emergence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth is positive because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
+              "description": "The direction of emergence is projected to the plane of the surface of the sample. The azimuth is the angle between this projection and the prime direction defined at `#/$defs/componentCharacteristics/properties/definitionOfSurfacesAndPrimeDirection`. It can have values between 0° and 360°. If we look at the sample as if it was a clock, the prime direction being 12 o'clock and the projection 11 o'clock, then the azimuth equals 30° because of the right-handed coordinate system of [ISO 80000-2:2019, Quantities and units - Part 2: Mathematics](https://www.iso.org/standard/64973.html)."
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
I have restructured geometric assemblies which include the location and orientation of components. collectorFieldAsGeometricAssembly.json is now an example how the geometric information about a collector field can be exchanged.

I made metabase.graphql valid to allow the future validation of metabase queries.

Closes #252 and #253