### PR TITLE
Make the coordinates of `location` more intuitive

### DIFF
--- a/examples/dbe/assembly/collectorFieldAsGeometricAssembly.json
+++ b/examples/dbe/assembly/collectorFieldAsGeometricAssembly.json
@@ -24,8 +24,8 @@
                 }
               },
               "location": {
-                "south": 0,
                 "east": 5,
+                "north": 0,
                 "elevation": 5
               },
               "orientation": {
@@ -44,8 +44,8 @@
                 }
               },
               "location": {
-                "south": -5,
                 "east": 0,
+                "north": 5,
                 "elevation": 5
               },
               "orientation": {

--- a/schemas/geometry.json
+++ b/schemas/geometry.json
@@ -60,13 +60,13 @@
       "title": "The location of the center of mass of the component.",
       "type": "object",
       "properties": {
-        "south": {
-          "$ref": "number.json#/$defs/meter",
-          "description": "This distance is measured horizontally in the direction from the `origin` to the south. It has the SI unit of meter."
-        },
         "east": {
           "$ref": "number.json#/$defs/meter",
           "description": "This distance is measured horizontally in the direction from the `origin` to the east. It has the SI unit of meter."
+        },
+        "north": {
+          "$ref": "number.json#/$defs/meter",
+          "description": "This distance is measured horizontally in the direction from the `origin` to the north. It has the SI unit of meter."
         },
         "elevation": {
           "$ref": "number.json#/$defs/meter",
@@ -74,7 +74,7 @@
         }
       },
       "additionalProperties": false,
-      "required": ["south", "east"]
+      "required": ["east", "north"]
     },
     "orientation": {
       "title": "The orientation of the prime surface of the component.",


### PR DESCRIPTION
Instead of `south` and `east`, the coordinates are now `east` and `north`. They can be considerer as the x-axis and y-axis and their orientation fits to the typical view on a north-oriented map.